### PR TITLE
Core/Scripts: fix lookup quest command crash

### DIFF
--- a/src/server/game/Chat/Chat.cpp
+++ b/src/server/game/Chat/Chat.cpp
@@ -71,17 +71,6 @@ std::vector<ChatCommand> const& ChatHandler::getCommandTable()
     return commandTableCache;
 }
 
-std::string ChatHandler::PGetParseString(int32 entry, ...) const
-{
-    const char *format = GetTrinityString(entry);
-    char str[1024];
-    va_list ap;
-    va_start(ap, entry);
-    vsnprintf(str, 1024, format, ap);
-    va_end(ap);
-    return std::string(str);
-}
-
 const char *ChatHandler::GetTrinityString(int32 entry) const
 {
     return m_session->GetTrinityString(entry);

--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -62,7 +62,6 @@ class ChatHandler
         virtual void SendSysMessage(const char *str);
 
         void SendSysMessage(int32 entry);
-        std::string PGetParseString(int32 entry, ...) const;
 
         template<typename... Args>
         void PSendSysMessage(const char* fmt, Args&&... args)
@@ -74,6 +73,12 @@ class ChatHandler
         void PSendSysMessage(uint32 entry, Args&&... args)
         {
             SendSysMessage(PGetParseString(entry, std::forward<Args>(args)...).c_str());
+        }
+
+        template<typename... Args>
+        std::string PGetParseString(int32 entry, Args&&... args) const
+        {
+            return fmt::sprintf(GetTrinityString(entry), std::forward<Args>(args)...);
         }
 
         int ParseCommands(const char* text);

--- a/src/server/scripts/Commands/cs_list.cpp
+++ b/src/server/scripts/Commands/cs_list.cpp
@@ -677,7 +677,7 @@ public:
             Field* fields = result->Fetch();
             uint32 countMail = fields[0].GetUInt32();
             std::string nameLink = handler->playerLink(targetName);
-            handler->PSendSysMessage(LANG_LIST_MAIL_HEADER, countMail, nameLink.c_str(), targetGuid);
+            handler->PSendSysMessage(LANG_LIST_MAIL_HEADER, countMail, nameLink.c_str(), targetGuid.ToString().c_str());
             handler->PSendSysMessage(LANG_ACCOUNT_LIST_BAR);
             CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_MAIL_LIST_INFO);
             stmt->setUInt64(0, targetGuid.GetGUIDLow());

--- a/src/server/scripts/Commands/cs_lookup.cpp
+++ b/src/server/scripts/Commands/cs_lookup.cpp
@@ -652,7 +652,7 @@ public:
                 }
 
                 if (handler->GetSession())
-                    handler->PSendSysMessage(LANG_QUEST_LIST_CHAT, qInfo->GetQuestId(), qInfo->GetQuestId(), qInfo->Level, title.c_str(), statusStr);
+                    handler->PSendSysMessage(LANG_QUEST_LIST_CHAT, qInfo->GetQuestId(), qInfo->GetQuestId(), qInfo->Level, qInfo->MinLevel, qInfo->MaxScalingLevel, title.c_str(), statusStr);
                 else
                     handler->PSendSysMessage(LANG_QUEST_LIST_CONSOLE, qInfo->GetQuestId(), title.c_str(), statusStr);
 

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -711,7 +711,7 @@ public:
 
         creature->AI()->SetData(data_1, data_2);
         std::string AIorScript = creature->GetNPCAIName() != "" ? "AI type: " + creature->GetNPCAIName() : (creature->GetScriptName() != "" ? "Script Name: " + creature->GetScriptName() : "No AI or Script Name Set");
-        handler->PSendSysMessage(LANG_NPC_SETDATA, creature->GetGUID(), creature->GetEntry(), creature->GetName(), data_1, data_2, AIorScript.c_str());
+        handler->PSendSysMessage(LANG_NPC_SETDATA, creature->GetGUID().ToString().c_str(), creature->GetEntry(), creature->GetName(), data_1, data_2, AIorScript.c_str());
         return true;
     }
 


### PR DESCRIPTION
`LANG_QUEST_LIST_CHAT` was formatted with the wrong number of arguments for this core.

Also updated `Chat::PGetParseString`.