### PR TITLE
Core/Quests: fix area trigger quest push and quest chain popup

### DIFF
--- a/sql/updates/world/2024_10_31_smart_script_offer_quest.sql
+++ b/sql/updates/world/2024_10_31_smart_script_offer_quest.sql
@@ -1,0 +1,2 @@
+UPDATE `smart_scripts` SET `action_param2`=1, `action_param3`=0, `action_param4`=0, `action_param5`=0, `action_param6`=0 WHERE `action_type`=7;
+UPDATE `smart_scripts` SET `action_param2`=0 WHERE `source_type`=2 AND `entryorguid`=6325 and `action_type`=7;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.cpp
@@ -829,7 +829,7 @@ bool SmartAIMgr::IsEventValid(SmartScriptHolder& e)
             }
             break;
         case SMART_ACTION_FAIL_QUEST:
-        case SMART_ACTION_ADD_QUEST:
+        case SMART_ACTION_OFFER_QUEST:
             if (!e.action.quest.quest || !IsQuestValid(e, e.action.quest.quest))
                 return false;
             break;

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -466,7 +466,7 @@ enum SMART_ACTION
     SMART_ACTION_SOUND                              = 4,      // SoundId, TextRange
     SMART_ACTION_PLAY_EMOTE                         = 5,      // EmoteId
     SMART_ACTION_FAIL_QUEST                         = 6,      // QuestID
-    SMART_ACTION_ADD_QUEST                          = 7,      // QuestID
+    SMART_ACTION_OFFER_QUEST                        = 7,      // QuestID, directAdd
     SMART_ACTION_SET_REACT_STATE                    = 8,      // state
     SMART_ACTION_ACTIVATE_GOBJECT                   = 9,      //
     SMART_ACTION_RANDOM_EMOTE                       = 10,     // EmoteId1, EmoteId2, EmoteId3...
@@ -655,11 +655,13 @@ struct SmartAction
         struct
         {
             uint32 quest;
-            uint32 prequest;
-            uint32 check;
-            uint32 queststate;
-            uint32 prequeststate;
         } quest;
+
+        struct
+        {
+            uint32 questID;
+            uint32 directAdd;
+        } questOffer;
 
         struct
         {

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -190,6 +190,9 @@ m_achievementMgr(sf::safe_ptr<AchievementMgr<Player>>(this))
 
     m_session = session;
 
+    m_sharedQuestId = 0;
+    m_popupQuestId = 0;
+
     m_ExtraFlags = 0;
 
     m_spellModTakingSpell = NULL;
@@ -18502,7 +18505,10 @@ void Player::SendPreparedQuest(ObjectGuid guid)
                 else if (quest->IsAutoComplete() && !quest->IsDailyOrWeekly() && !quest->IsMonthly())
                     PlayerTalkClass->SendQuestGiverRequestItems(quest, object->GetGUID(), CanRewardQuest(quest, false), true);
                 else
+                {
+                    SetPopupQuestId(0);
                     PlayerTalkClass->SendQuestGiverQuestDetails(quest, object->GetGUID(), true, false);
+                }
             }
 
             return;
@@ -18523,6 +18529,11 @@ void Player::SendPreparedQuest(ObjectGuid guid)
     }
 
     PlayerTalkClass->SendQuestGiverQuestList(BroadcastTextID, guid);
+}
+
+bool Player::IsActiveQuest(uint32 quest_id) const
+{
+    return m_QuestStatus.find(quest_id) != m_QuestStatus.end();
 }
 
 Quest const* Player::GetNextQuest(ObjectGuid guid, Quest const* quest)

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1923,6 +1923,7 @@ class Player : public Unit, public GridObject<Player>
         void PrepareAreaQuest(uint32 area);
         void PrepareQuestMenu(ObjectGuid guid);
         void SendPreparedQuest(ObjectGuid guid);
+        bool IsActiveQuest(uint32 quest_id) const;
         Quest const* GetNextQuest(ObjectGuid guid, Quest const* quest);
         bool CanSeeStartQuest(Quest const* quest);
         bool CanTakeQuest(Quest const* quest, bool msg);
@@ -2038,6 +2039,10 @@ class Player : public Unit, public GridObject<Player>
         ObjectGuid GetPlayerSharingQuest() const { return m_playerSharingQuest; }
         void SetQuestSharingInfo(ObjectGuid guid, uint32 id) { m_playerSharingQuest = guid; m_sharedQuestId = id; }
         void ClearQuestSharingInfo() { m_playerSharingQuest = ObjectGuid::Empty; m_sharedQuestId = 0; }
+
+        // Returns the ID of the next available quest in chain of the most recently rewarded quest that has been rewarded via UI popup
+        uint32 GetPopupQuestId() const { return m_popupQuestId; }
+        void SetPopupQuestId(uint32 questId) { m_popupQuestId = questId; }
 
         uint32 GetInGameTime() { return m_ingametime; }
         void SetInGameTime(uint32 time) { m_ingametime = time; }
@@ -3301,6 +3306,7 @@ class Player : public Unit, public GridObject<Player>
 
         ObjectGuid m_playerSharingQuest;
         uint32 m_sharedQuestId;
+        uint32 m_popupQuestId;
         uint32 m_ingametime;
 
         /*********************************************************/

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -7675,10 +7675,14 @@ void Spell::EffectQuestStart(SpellEffIndex effIndex)
         if (qInfo->IsAutoAccept() && player->CanAddQuest(qInfo, false))
         {
             player->AddQuestAndCheckCompletion(qInfo, player);
+            player->SetPopupQuestId(0);
             player->PlayerTalkClass->SendQuestGiverQuestDetails(qInfo, player->GetGUID(), true, true);
         }
         else
+        {
+            player->SetPopupQuestId(qInfo->GetQuestId());
             player->PlayerTalkClass->SendQuestGiverQuestDetails(qInfo, player->GetGUID(), true, false);
+        }
     }
 }
 


### PR DESCRIPTION
This fixes multiple issues with the quest system.

SMART_ACTION_ADD_QUEST -> SMART_ACTION_OFFER_QUEST from https://github.com/TrinityCore/TrinityCore/commit/573cb9d20f01bdc6dce8763aa9affa9ed2ae3679

  - This updates the smart script system to offer quests via popup rather than adding straight to the quest log. The old behavior is maintained for all quests except the one that I tested https://www.wowhead.com/quest=27697/corruption-in-maraudon which is offered via area trigger when you first enter the instance.

  - Area trigger quest push (using SMART_ACTION_OFFER_QUEST) has also been updated to only offer quests that have NOT already been completed, when `directAdd` is not used.

Fix follow up popup quests from https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/4f23fb3d29fc8f30bdcbf0c341fc5b25e731b1da

  - This fixes quest chains that are given through popups, like https://www.wowhead.com/quest=194/raptor-hunting. Now, follow up quest popups (offered by the player, not by an npc) can be accepted.