### PR TITLE
Core/PacketIO: use local time in packets instead of UTC

### DIFF
--- a/src/common/Utilities/Timer.h
+++ b/src/common/Utilities/Timer.h
@@ -21,13 +21,20 @@
 
 #include "Duration.h"
 
-inline uint32 getMSTime()
+inline TimePoint GetApplicationStartTime()
 {
     using namespace std::chrono;
 
     static const steady_clock::time_point ApplicationStartTime = steady_clock::now();
 
-    return uint32(duration_cast<milliseconds>(steady_clock::now() - ApplicationStartTime).count());
+    return ApplicationStartTime;
+}
+
+inline uint32 getMSTime()
+{
+    using namespace std::chrono;
+
+    return uint32(duration_cast<milliseconds>(steady_clock::now() - GetApplicationStartTime()).count());
 }
 
 inline uint32 getMSTimeDiff(uint32 oldMSTime, uint32 newMSTime)

--- a/src/common/Utilities/WowTime.cpp
+++ b/src/common/Utilities/WowTime.cpp
@@ -28,14 +28,6 @@ uint32 WowTime::Encode()
     return uint32((Minute & 63) | ((Hour & 31) << 6) | ((WeekDay & 7) << 11) | ((MonthDay & 63) << 14) | ((Month & 15) << 20) | ((Year & 31) << 24) | ((Unk1 & 3) << 29));
 }
 
-uint32 WowTime::Encode(time_t time)
-{
-    WowTime wTime;
-    wTime.SetUTCTimeFromPosixTime(time);
-
-    return wTime.Encode();
-}
-
 void WowTime::Decode(uint32 encodedTime)
 {
     int temp = encodedTime & 0x3F;

--- a/src/common/Utilities/WowTime.hpp
+++ b/src/common/Utilities/WowTime.hpp
@@ -46,7 +46,6 @@ namespace MS
             WowTime();
 
             uint32 Encode();
-            static uint32 Encode(time_t p_Time);
             void Decode(uint32 p_EncodedTime);
             static WowTime FromEncodedTime(uint32 p_EncodedTime);
 

--- a/src/server/game/Calendar/CalendarMgr.cpp
+++ b/src/server/game/Calendar/CalendarMgr.cpp
@@ -456,7 +456,7 @@ std::string CalendarEvent::BuildCalendarMailBody() const
     uint32 time;
     std::ostringstream strm;
 
-    data << MS::Utilities::WowTime::Encode(_date);
+    data.AppendPackedTime(_date);
     data >> time;
     strm << time;
     return strm.str();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -29911,13 +29911,12 @@ void Player::SendInitialPacketsBeforeAddToMap(bool login)
     if (login) // Don`t send when teleported
     {
         SendEquipmentSetList();
-        uint32 speedtime = ((GameTime::GetGameTime() - GameTime::GetUptime()) + (GameTime::GetUptime()));
         m_achievementMgr->SendAllAchievementData(this);
 
         WorldPackets::Misc::LoginSetTimeSpeed loginSetTimeSpeed;
         loginSetTimeSpeed.NewSpeed = 0.01666667f;
-        loginSetTimeSpeed.GameTime = speedtime;
-        loginSetTimeSpeed.ServerTime = speedtime;
+        loginSetTimeSpeed.GameTime = GameTime::GetGameTime();
+        loginSetTimeSpeed.ServerTime = GameTime::GetGameTime();
         SendDirectMessage(loginSetTimeSpeed.Write());
     }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17778,7 +17778,7 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* target, uint32 procFlag, u
     HealInfo healInfo = HealInfo(actor, actionTarget, dmgInfoProc->GetDamage(), procSpell, procSpell ? SpellSchoolMask(procSpell->GetMisc(m_spawnMode)->MiscData.SchoolMask) : SPELL_SCHOOL_MASK_NORMAL);
     ProcEventInfo eventInfo = ProcEventInfo(actor, actionTarget, target, procFlag, 0, 0, procExtra, spell, dmgInfoProc, &healInfo);
 
-    std::chrono::steady_clock::time_point now = GameTime::GetGameTimeSteadyPoint();
+    TimePoint now = GameTime::Now();
     ProcTriggeredList procTriggered;
     // Fill procTriggered list
     for (AuraApplicationMap::const_iterator itr = GetAppliedAuras().begin(); itr!= GetAppliedAuras().end(); ++itr)

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -700,7 +700,7 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder const& holder)
 
     WorldPackets::ClientConfig::AccountDataTimes accountDataTimes;
     accountDataTimes.PlayerGuid = playerGuid;
-    accountDataTimes.ServerTime = GameTime::GetGameTimeSystemPoint();
+    accountDataTimes.ServerTime = GameTime::GetSystemTime();
     for (uint32 i = 0; i < NUM_ACCOUNT_DATA_TYPES; ++i)
         accountDataTimes.AccountTimes[i] = uint32(GetAccountData(AccountDataType(i))->Time);
 

--- a/src/server/game/Server/Packets/AchievementPackets.cpp
+++ b/src/server/game/Server/Packets/AchievementPackets.cpp
@@ -21,7 +21,7 @@
 ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Achievement::EarnedAchievement const& earned)
 {
     data << uint32(earned.Id);
-    data << MS::Utilities::WowTime::Encode(earned.Date);
+    data.AppendPackedTime(earned.Date);
     data << earned.Owner;
     data << uint32(earned.VirtualRealmAddress);
     data << uint32(earned.NativeRealmAddress);
@@ -34,7 +34,7 @@ ByteBuffer& operator<<(ByteBuffer& _worldPacket, WorldPackets::Achievement::Crit
     _worldPacket << uint32(progress.Id);
     _worldPacket << uint64(progress.Quantity);
     _worldPacket << progress.Player;
-    _worldPacket << MS::Utilities::WowTime::Encode(progress.Date);
+    _worldPacket.AppendPackedTime(progress.Date);
     _worldPacket << uint32(progress.TimeFromStart);
     _worldPacket << uint32(progress.TimeFromCreate);
     _worldPacket.WriteBits(progress.Flags, 4);
@@ -70,7 +70,7 @@ WorldPacket const* WorldPackets::Achievement::CriteriaUpdate::Write()
     _worldPacket << uint64(Quantity);
     _worldPacket << PlayerGUID;
     _worldPacket << uint32(Flags);
-    _worldPacket << MS::Utilities::WowTime::Encode(CurrentTime);
+    _worldPacket.AppendPackedTime(CurrentTime);
     _worldPacket << uint32(ElapsedTime);
     _worldPacket << uint32(CreationTime);
 
@@ -97,7 +97,7 @@ WorldPacket const* WorldPackets::Achievement::AchievementEarned::Write()
     _worldPacket << Sender;
     _worldPacket << Earner;
     _worldPacket << uint32(AchievementID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Time);
+    _worldPacket.AppendPackedTime(Time);
     _worldPacket << uint32(EarnerNativeRealm);
     _worldPacket << uint32(EarnerVirtualRealm);
     _worldPacket.WriteBit(Initial);
@@ -126,7 +126,7 @@ WorldPacket const* WorldPackets::Achievement::GuildCriteriaUpdate::Write()
         _worldPacket << int32(progress.CriteriaID);
         _worldPacket << uint32(progress.DateCreated);
         _worldPacket << uint32(progress.DateStarted);
-        _worldPacket << MS::Utilities::WowTime::Encode(progress.DateUpdated);
+        _worldPacket.AppendPackedTime(progress.DateUpdated);
         _worldPacket << uint64(progress.Quantity);
         _worldPacket << progress.PlayerGUID;
         _worldPacket << int32(progress.Flags);
@@ -152,7 +152,7 @@ WorldPacket const* WorldPackets::Achievement::GuildAchievementDeleted::Write()
 {
     _worldPacket << GuildGUID;
     _worldPacket << uint32(AchievementID);
-    _worldPacket << MS::Utilities::WowTime::Encode(TimeDeleted);
+    _worldPacket.AppendPackedTime(TimeDeleted);
 
     return &_worldPacket;
 }
@@ -161,7 +161,7 @@ WorldPacket const* WorldPackets::Achievement::GuildAchievementEarned::Write()
 {
     _worldPacket << GuildGUID;
     _worldPacket << uint32(AchievementID);
-    _worldPacket << MS::Utilities::WowTime::Encode(TimeEarned);
+    _worldPacket.AppendPackedTime(TimeEarned);
 
     return &_worldPacket;
 }

--- a/src/server/game/Server/Packets/BattlePetPackets.cpp
+++ b/src/server/game/Server/Packets/BattlePetPackets.cpp
@@ -89,7 +89,7 @@ WorldPacket const* WorldPackets::BattlePet::QueryResponse::Write()
 {
     _worldPacket << BattlePetID;
     _worldPacket << CreatureID;
-    _worldPacket << MS::Utilities::WowTime::Encode(Timestamp);
+    _worldPacket.AppendPackedTime(Timestamp);
     if (!_worldPacket.WriteBit(Allow))
         return &_worldPacket;
 

--- a/src/server/game/Server/Packets/CalendarPackets.cpp
+++ b/src/server/game/Server/Packets/CalendarPackets.cpp
@@ -23,7 +23,7 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Calendar::CalendarSendCal
 {
     data << uint64(eventInfo.EventID);
     data << uint8(eventInfo.EventType);
-    data << MS::Utilities::WowTime::Encode(eventInfo.Date);
+    data.AppendPackedTime(eventInfo.Date);
     data << uint32(eventInfo.Flags);
     data << int32(eventInfo.TextureID);
     data << eventInfo.EventGuildID;
@@ -66,7 +66,7 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Calendar::CalendarEventIn
     data << uint8(inviteInfo.Moderator);
     data << uint8(inviteInfo.InviteType);
 
-    data << MS::Utilities::WowTime::Encode(inviteInfo.ResponseTime);
+    data.AppendPackedTime(inviteInfo.ResponseTime);
 
     data.WriteBits(inviteInfo.Notes.size(), 8);
     data.WriteString(inviteInfo.Notes);
@@ -218,7 +218,7 @@ WorldPacket const* WorldPackets::Calendar::SCalendarEventInvite::Write()
     _worldPacket << uint8(Level);
     _worldPacket << uint8(Status);
     _worldPacket << uint8(Type);
-    _worldPacket << MS::Utilities::WowTime::Encode(ResponseTime);
+    _worldPacket.AppendPackedTime(ResponseTime);
 
     _worldPacket.WriteBit(ClearPending);
     _worldPacket.FlushBits();
@@ -228,7 +228,7 @@ WorldPacket const* WorldPackets::Calendar::SCalendarEventInvite::Write()
 
 WorldPacket const* WorldPackets::Calendar::CalendarSendCalendar::Write()
 {
-    _worldPacket << MS::Utilities::WowTime::Encode(ServerTime);
+    _worldPacket.AppendPackedTime(ServerTime);
     _worldPacket << static_cast<uint32>(Invites.size());
     _worldPacket << static_cast<uint32>(Events.size());
     _worldPacket << static_cast<uint32>(RaidLockouts.size());
@@ -253,7 +253,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarSendEvent::Write()
     _worldPacket << uint8(GetEventType);
     _worldPacket << int32(TextureID);
     _worldPacket << uint32(Flags);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(LockDate);
     _worldPacket << EventGuildID;
 
@@ -274,7 +274,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarSendEvent::Write()
 WorldPacket const* WorldPackets::Calendar::CalendarEventInviteAlert::Write()
 {
     _worldPacket << uint64(EventID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(Flags);
     _worldPacket << uint8(EventType);
     _worldPacket << int32(TextureID);
@@ -296,10 +296,10 @@ WorldPacket const* WorldPackets::Calendar::CalendarEventInviteStatus::Write()
 {
     _worldPacket << InviteGuid;
     _worldPacket << uint64(EventID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(Flags);
     _worldPacket << uint8(Status);
-    _worldPacket << MS::Utilities::WowTime::Encode(ResponseTime);
+    _worldPacket.AppendPackedTime(ResponseTime);
 
     _worldPacket.WriteBit(ClearPending);
     _worldPacket.FlushBits();
@@ -334,7 +334,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarEventInviteModeratorStatus::W
 WorldPacket const* WorldPackets::Calendar::CalendarEventInviteRemovedAlert::Write()
 {
     _worldPacket << uint64(EventID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(Flags);
     _worldPacket << uint8(Status);
 
@@ -345,8 +345,8 @@ WorldPacket const* WorldPackets::Calendar::CalendarEventUpdatedAlert::Write()
 {
     _worldPacket << uint64(EventID);
 
-    _worldPacket << MS::Utilities::WowTime::Encode(OriginalDate);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(OriginalDate);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(LockDate);
     _worldPacket << uint32(Flags);
     _worldPacket << uint32(TextureID);
@@ -364,7 +364,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarEventUpdatedAlert::Write()
 WorldPacket const* WorldPackets::Calendar::CalendarEventRemovedAlert::Write()
 {
     _worldPacket << uint64(EventID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
 
     _worldPacket.WriteBit(ClearPending);
     _worldPacket.FlushBits();
@@ -393,7 +393,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarCommandResult::Write()
 WorldPacket const* WorldPackets::Calendar::CalendarRaidLockoutAdded::Write()
 {
     _worldPacket << uint64(InstanceID);
-    _worldPacket << MS::Utilities::WowTime::Encode(ServerTime);
+    _worldPacket.AppendPackedTime(ServerTime);
     _worldPacket << int32(MapID);
     _worldPacket << uint32(DifficultyID);
     _worldPacket << int32(TimeRemaining);
@@ -436,7 +436,7 @@ WorldPacket const* WorldPackets::Calendar::CalendarEventInitialInvites::Write()
 WorldPacket const* WorldPackets::Calendar::CalendarEventInviteStatusAlert::Write()
 {
     _worldPacket << uint64(EventID);
-    _worldPacket << MS::Utilities::WowTime::Encode(Date);
+    _worldPacket.AppendPackedTime(Date);
     _worldPacket << uint32(Flags);
     _worldPacket << uint8(Status);
 

--- a/src/server/game/Server/Packets/ChallengeModePackets.cpp
+++ b/src/server/game/Server/Packets/ChallengeModePackets.cpp
@@ -23,7 +23,7 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::ChallengeMode::ModeAttemp
     data << modeAttempt.InstanceRealmAddress;
     data << modeAttempt.AttemptID;
     data << modeAttempt.CompletionTime;
-    data << MS::Utilities::WowTime::Encode(modeAttempt.CompletionDate);
+    data.AppendPackedTime(modeAttempt.CompletionDate);
     data << modeAttempt.MedalEarned;
     data << static_cast<uint32>(modeAttempt.Members.size());
     for (auto const& map : modeAttempt.Members)
@@ -75,7 +75,7 @@ ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::ChallengeMode::ChallengeM
     data << challengeModeMap.BestCompletionMilliseconds;
     data << challengeModeMap.LastCompletionMilliseconds;
     data << challengeModeMap.CompletedChallengeLevel;
-    data << MS::Utilities::WowTime::Encode(challengeModeMap.BestMedalDate);
+    data.AppendPackedTime(challengeModeMap.BestMedalDate);
 
     data << static_cast<uint32>(challengeModeMap.BestSpecID.size());
 
@@ -100,8 +100,8 @@ WorldPacket const* WorldPackets::ChallengeMode::RequestLeadersResult::Write()
 {
     _worldPacket << MapID;
     _worldPacket << ChallengeID;
-    _worldPacket << MS::Utilities::WowTime::Encode(LastGuildUpdate);
-    _worldPacket << MS::Utilities::WowTime::Encode(LastRealmUpdate);
+    _worldPacket.AppendPackedTime(LastGuildUpdate);
+    _worldPacket.AppendPackedTime(LastRealmUpdate);
 
     _worldPacket << static_cast<uint32>(GuildLeaders.size());
     _worldPacket << static_cast<uint32>(RealmLeaders.size());

--- a/src/server/game/Server/Packets/GuildPackets.cpp
+++ b/src/server/game/Server/Packets/GuildPackets.cpp
@@ -83,7 +83,7 @@ WorldPacket const* WorldPackets::Guild::GuildCommandResult::Write()
 WorldPacket const* WorldPackets::Guild::GuildRoster::Write()
 {
     _worldPacket << NumAccounts;
-    _worldPacket << MS::Utilities::WowTime::Encode(CreateDate);
+    _worldPacket.AppendPackedTime(CreateDate);
     _worldPacket << GuildFlags;
     _worldPacket << uint32(MemberData.size());
     _worldPacket.WriteBits(WelcomeText.length(), 10);
@@ -842,7 +842,7 @@ void WorldPackets::Guild::GuildQueryNews::Read()
 ByteBuffer& operator<<(ByteBuffer& data, WorldPackets::Guild::GuildNewsEvent const& newsEvent)
 {
     data << newsEvent.Id;
-    data << MS::Utilities::WowTime::Encode(newsEvent.CompletedDate);
+    data.AppendPackedTime(newsEvent.CompletedDate);
     data << newsEvent.Type;
     data << newsEvent.Flags;
 

--- a/src/server/game/Server/Packets/MiscPackets.cpp
+++ b/src/server/game/Server/Packets/MiscPackets.cpp
@@ -37,8 +37,8 @@ WorldPacket const* WorldPackets::Misc::InvalidatePlayer::Write()
 
 WorldPacket const* WorldPackets::Misc::LoginSetTimeSpeed::Write()
 {
-    _worldPacket << MS::Utilities::WowTime::Encode(ServerTime);
-    _worldPacket << MS::Utilities::WowTime::Encode(GameTime);
+    _worldPacket.AppendPackedTime(ServerTime);
+    _worldPacket.AppendPackedTime(GameTime);
     _worldPacket << float(NewSpeed);
     _worldPacket << uint32(ServerTimeHolidayOffset);
     _worldPacket << uint32(GameTimeHolidayOffset);

--- a/src/server/game/Server/Packets/PacketUtilities.h
+++ b/src/server/game/Server/Packets/PacketUtilities.h
@@ -101,7 +101,7 @@ namespace WorldPackets
     public:
         Timestamp() = default;
         Timestamp(time_t value) : _value(value) { }
-        Timestamp(std::chrono::system_clock::time_point const& systemTime) : _value(std::chrono::system_clock::to_time_t(systemTime)) { }
+        Timestamp(SystemTimePoint const& systemTime) : _value(std::chrono::system_clock::to_time_t(systemTime)) { }
 
         Timestamp& operator=(time_t value)
         {
@@ -109,7 +109,7 @@ namespace WorldPackets
             return *this;
         }
 
-        Timestamp& operator=(std::chrono::system_clock::time_point const& systemTime)
+        Timestamp& operator=(SystemTimePoint const& systemTime)
         {
             _value = std::chrono::system_clock::to_time_t(systemTime);
             return *this;

--- a/src/server/game/Server/WorldSocket.h
+++ b/src/server/game/Server/WorldSocket.h
@@ -25,7 +25,6 @@
 #include "Util.h"
 #include "WorldPacketCrypt.h"
 #include "WorldSession.h"
-#include <chrono>
 #include <safe_ptr.h>
 
 struct z_stream_s;
@@ -138,7 +137,7 @@ private:
     BigNumber _decryptSeed;
     BigNumber _sessionKey;
 
-    std::chrono::steady_clock::time_point _LastPingTime;
+    TimePoint _LastPingTime;
     uint32 _OverSpeedPings;
     uint32 _accountId;
 

--- a/src/server/game/Time/GameTime.cpp
+++ b/src/server/game/Time/GameTime.cpp
@@ -26,8 +26,8 @@ namespace GameTime
     time_t GameTime = time(nullptr);
     uint32 GameMSTime = 0;
 
-    std::chrono::system_clock::time_point GameTimeSystemPoint = std::chrono::system_clock::time_point::min();
-    std::chrono::steady_clock::time_point GameTimeSteadyPoint = std::chrono::steady_clock::time_point::min();
+    SystemTimePoint GameTimeSystemPoint = SystemTimePoint::min();
+    TimePoint GameTimeSteadyPoint = TimePoint::min();
 
     tm DateTime;
 
@@ -46,14 +46,26 @@ namespace GameTime
         return GameMSTime;
     }
 
-    std::chrono::system_clock::time_point GetGameTimeSystemPoint()
+    SystemTimePoint GetSystemTime()
     {
         return GameTimeSystemPoint;
     }
 
-    std::chrono::steady_clock::time_point GetGameTimeSteadyPoint()
+    TimePoint Now()
     {
         return GameTimeSteadyPoint;
+    }
+
+    template<>
+    SystemTimePoint GetTime<std::chrono::system_clock>()
+    {
+        return GetSystemTime();
+    }
+
+    template<>
+    TimePoint GetTime<std::chrono::steady_clock>()
+    {
+        return Now();
     }
 
     uint32 GetUptime()

--- a/src/server/game/Time/GameTime.h
+++ b/src/server/game/Time/GameTime.h
@@ -19,8 +19,7 @@
 #define __GAMETIME_H
 
 #include "Define.h"
-
-#include <chrono>
+#include "Duration.h"
 
 namespace GameTime
 {
@@ -34,10 +33,14 @@ namespace GameTime
     uint32 GetGameTimeMS();
 
     /// Current chrono system_clock time point
-    std::chrono::system_clock::time_point GetGameTimeSystemPoint();
+    SystemTimePoint GetSystemTime();
 
     /// Current chrono steady_clock time point
-    std::chrono::steady_clock::time_point GetGameTimeSteadyPoint();
+    TimePoint Now();
+
+    /// Current chrono Clock time point
+    template<typename Clock>
+    typename Clock::time_point GetTime();
 
     /// Uptime (in secs)
     uint32 GetUptime();


### PR DESCRIPTION
This fixes the in-game day/night cycle to match local time (instead of always being UTC).

Fixes https://github.com/The-Legion-Preservation-Project/LegionCore-7.3.5/issues/93