### PR TITLE
Core: fix spell visual kit system

### DIFF
--- a/sql/updates/world/2024_11_01_fix_spell_visual_kit.sql
+++ b/sql/updates/world/2024_11_01_fix_spell_visual_kit.sql
@@ -1,0 +1,8 @@
+# action_param2 is now kit type
+UPDATE `smart_scripts` SET `action_param2` = 0 WHERE `action_type` = 27;
+
+# action_param3 is now duration
+UPDATE `smart_scripts` SET `action_param3` = 500 WHERE `action_type` = 27 and `entryorguid` = 8885900;
+
+UPDATE `spell_visual_kit` SET `KitRecID` = `KitType` WHERE `KitRecID` = 0;
+UPDATE `spell_visual_kit` SET `KitType` = 0;

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -587,10 +587,26 @@ void SmartScript::ProcessAction(SmartScriptHolder& e, Unit* unit, uint32 var0, u
             break;
         }
         case SMART_ACTION_PLAY_SPELL_VISUAL_KIT:
-            if (!me)
+        {
+            ObjectList* targets = GetTargets(e, unit);
+            if (!targets)
                 break;
-            me->SendPlaySpellVisualKit(e.action.visualKit.id, e.action.visualKit.duration);
+
+            for (auto target : *targets)
+            {
+                if (IsUnit(target))
+                {
+                    target->ToUnit()->SendPlaySpellVisualKit(e.action.spellVisualKit.spellVisualKitId, e.action.spellVisualKit.kitType,
+                        e.action.spellVisualKit.duration);
+
+                    TC_LOG_DEBUG("scripts.ai", "SmartScript::ProcessAction:: SMART_ACTION_PLAY_SPELL_VISUAL_KIT: target: %s (%s), SpellVisualKit: %u",
+                        target->GetName(), target->GetGUID().ToString().c_str(), e.action.spellVisualKit.spellVisualKitId);
+                }
+            }
+
+            delete targets;
             break;
+        }
         case SMART_ACTION_CAST:
         {
             if (e.GetTargetType() == SMART_TARGET_POSITION)

--- a/src/server/game/AI/SmartScripts/SmartScriptMgr.h
+++ b/src/server/game/AI/SmartScripts/SmartScriptMgr.h
@@ -1116,10 +1116,10 @@ struct SmartAction
 
         struct
         {
-            uint32 id;
+            uint32 spellVisualKitId;
+            uint32 kitType;
             uint32 duration;
-            uint32 KitRecID;
-        } visualKit;
+        } spellVisualKit;
 
         struct
         {

--- a/src/server/game/Server/Packets/SpellPackets.cpp
+++ b/src/server/game/Server/Packets/SpellPackets.cpp
@@ -1026,9 +1026,9 @@ WorldPacket const* WorldPackets::Spells::PlaySpellVisual::Write()
 WorldPacket const* WorldPackets::Spells::PlaySpellVisualKit::Write()
 {
     _worldPacket << Unit;
+    _worldPacket << KitRecID;
     _worldPacket << KitType;
     _worldPacket << Duration;
-    _worldPacket << KitRecID;
 
     return &_worldPacket;
 }

--- a/src/server/scripts/Legion/AntorusTheBurningThrone/boss_varimathras.cpp
+++ b/src/server/scripts/Legion/AntorusTheBurningThrone/boss_varimathras.cpp
@@ -304,7 +304,7 @@ struct npc_shadow_of_varimathras : public ScriptedAI
             me->AddDelayedEvent(100, [this] () -> void
             {
                 me->PlayOneShotAnimKit(13242);
-                me->SendPlaySpellVisualKit(0, 83768);
+                me->SendPlaySpellVisualKit(83768, 0);
             });
         }
 

--- a/src/server/scripts/Legion/MawofSouls/boss_helya.cpp
+++ b/src/server/scripts/Legion/MawofSouls/boss_helya.cpp
@@ -353,7 +353,7 @@ struct boss_helya : public BossAI
             introSpawn = true;
             eventDelay = true;
             me->RemoveStandStateFlags(UNIT_STAND_STATE_SUBMERGED);
-            me->SendPlaySpellVisualKit(0, VISUAL_KIT_1);
+            me->SendPlaySpellVisualKit(VISUAL_KIT_1, 0);
             AddDelayedEvent(5000, [=]() -> void { eventDelay = false; });
             return;
         }
@@ -362,7 +362,7 @@ struct boss_helya : public BossAI
         {
             introEvent = true;
             Talk(SAY_INTRO); //You ALL will regret trespassing in my realm.
-            me->SendPlaySpellVisualKit(0, VISUAL_KIT_2);
+            me->SendPlaySpellVisualKit(VISUAL_KIT_2, 0);
             events.RescheduleEvent(EVENT_INTRO, 5000);
         }
     }
@@ -655,7 +655,7 @@ struct boss_helya : public BossAI
             switch (eventId)
             {
                 case EVENT_INTRO:
-                    me->SendPlaySpellVisualKit(0, VISUAL_KIT_3);
+                    me->SendPlaySpellVisualKit(VISUAL_KIT_3, 0);
                     DoCast(me, SPELL_SOULLESS_SCREAM, true);
                     DoCast(me, SPELL_INTERFERE_TARGETTING, true);
                     SummonGrasping(true);

--- a/src/server/scripts/Legion/MicroHolidays/MoonkinFestival.cpp
+++ b/src/server/scripts/Legion/MicroHolidays/MoonkinFestival.cpp
@@ -417,7 +417,7 @@ struct npc_moonkin_hatchling_pet : ScriptedAI
     void SpellHit(Unit* /*caster*/, SpellInfo const* spell) override
     {
         if (spell->Id == 245342)
-            me->SendPlaySpellVisualKit(0, 84318, 0);
+            me->SendPlaySpellVisualKit(84318, 0, 0);
     }
 
     void UpdateAI(uint32 diff) override

--- a/src/server/scripts/Legion/TheEmeraldNightmare/boss_cenarius.cpp
+++ b/src/server/scripts/Legion/TheEmeraldNightmare/boss_cenarius.cpp
@@ -1073,7 +1073,7 @@ struct npc_cenarius_nightmare_brambles : public ScriptedAI
                     break;
                 }
                 case EVENT_3:
-                    me->SendPlaySpellVisualKit(0, BRAMBLES_KIT_1);
+                    me->SendPlaySpellVisualKit(BRAMBLES_KIT_1, 0);
                     if (auto player = Player::GetPlayer(*me, playerGUID))
                         me->GetMotionMaster()->MovePoint(1, player->GetPosition());
                     events.RescheduleEvent(EVENT_3, 1000);

--- a/src/server/scripts/Legion/TheNighthold/boss_skorpyron.cpp
+++ b/src/server/scripts/Legion/TheNighthold/boss_skorpyron.cpp
@@ -245,7 +245,7 @@ struct boss_skorpyron : BossAI
     {
         if (spell->Id == SPELL_FOCUSED_BLAST_AT)
         {
-            me->SendPlaySpellVisualKit(0, VISUAL_KIT_BLAST);
+            me->SendPlaySpellVisualKit(VISUAL_KIT_BLAST, 0);
 
             float z = me->GetPositionZ();
             float lineDistance = 2.5f;

--- a/src/server/scripts/Legion/TheNighthold/boss_tichondrius.cpp
+++ b/src/server/scripts/Legion/TheNighthold/boss_tichondrius.cpp
@@ -541,7 +541,7 @@ struct npc_tichonrius_carrion_nightmare : ScriptedAI
                     break;
                 }
                 case EVENT_2:
-                    me->SendPlaySpellVisualKit(0, 66613, 0);
+                    me->SendPlaySpellVisualKit(66613, 0, 0);
                     break;
                 case EVENT_3:
                     me->DespawnOrUnsummon();

--- a/src/server/scripts/Legion/TombOfSargeras/boss_TheDesolateHost.cpp
+++ b/src/server/scripts/Legion/TombOfSargeras/boss_TheDesolateHost.cpp
@@ -753,7 +753,7 @@ struct npc_tos_desolate_host : ScriptedAI
                     me->SetVisible(true);
                     Talk(SAY_HOST_AGGRO);
                     DoCast(me, SPELL_SHARED_HEALTH, true);
-                    me->SendPlaySpellVisualKit(0, VISUAL_KIT_1);
+                    me->SendPlaySpellVisualKit(VISUAL_KIT_1, 0);
                     me->HandleEmoteCommand(EMOTE_ONESHOT_BATTLE_ROAR);
                     me->SetReactState(REACT_AGGRESSIVE, 2000);
                     DoZoneInCombat(me, 100.0f);
@@ -868,7 +868,7 @@ struct npc_tos_reanimated_templar : ScriptedAI
         if (!mirror)
         {
             if (instance->GetBossState(DATA_THE_DESOLATE_HOST) == IN_PROGRESS)
-                me->SendPlaySpellVisualKit(0, VISUAL_KIT_2);
+                me->SendPlaySpellVisualKit(VISUAL_KIT_2, 0);
             else
                 me->SetStandState(UNIT_STAND_STATE_KNEEL);
 
@@ -973,7 +973,7 @@ struct npc_tos_ghastly_bonewarden : ScriptedAI
         if (!mirror)
         {
             if (instance->GetBossState(DATA_THE_DESOLATE_HOST) == IN_PROGRESS)
-                me->SendPlaySpellVisualKit(0, VISUAL_KIT_2);
+                me->SendPlaySpellVisualKit(VISUAL_KIT_2, 0);
             else
                 DoCast(me, SPELL_SHADOW_CHANNELLING, true);
 
@@ -1086,7 +1086,7 @@ struct npc_tos_fallen_priestess : ScriptedAI
         if (!mirror)
         {
             if (instance->GetBossState(DATA_THE_DESOLATE_HOST) == IN_PROGRESS)
-                me->SendPlaySpellVisualKit(0, VISUAL_KIT_2);
+                me->SendPlaySpellVisualKit(VISUAL_KIT_2, 0);
             else
                 DoCast(me, SPELL_SOUL_REND, true);
 
@@ -1196,7 +1196,7 @@ struct npc_tos_soul_residue : ScriptedAI
         if (!mirror)
         {
             if (instance->GetBossState(DATA_THE_DESOLATE_HOST) == IN_PROGRESS)
-                me->SendPlaySpellVisualKit(0, VISUAL_KIT_2);
+                me->SendPlaySpellVisualKit(VISUAL_KIT_2, 0);
 
             if (IsMythicRaid())
                 DoCast(me, SPELL_BOUND_ESSENCE_AURA, true);

--- a/src/server/scripts/Legion/VioletHoldLegion/boss_millificent_manastorm.cpp
+++ b/src/server/scripts/Legion/VioletHoldLegion/boss_millificent_manastorm.cpp
@@ -492,7 +492,7 @@ public:
                 me->RemoveAurasDueToSpell(SPELL_OVERLOADED);
                 me->InterruptNonMeleeSpells(false);
                 //DoCast(me, SPELL_EJECT_ALL_PASSENGERS, true);
-                me->SendPlaySpellVisualKit(0, 63152);
+                me->SendPlaySpellVisualKit(63152, 0);
                 diedTimer = 2000;
                 disarmed = true;
             }

--- a/src/server/scripts/Scenario/Artifacts/Paladin/BrokenShore/broken_shore.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Paladin/BrokenShore/broken_shore.cpp
@@ -931,7 +931,7 @@ public:
                 summons.DespawnAll();
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_ATTACKABLE_1);
                 DoCast(me, 152821, true); //Morph
-                me->SendPlaySpellVisualKit(0, 61036); //SMSG_PLAY_SPELL_VISUAL_KIT
+                me->SendPlaySpellVisualKit(61036, 0); //SMSG_PLAY_SPELL_VISUAL_KIT
                 if (instance->getScenarionStep() == DATA_STAGE_6)
                     instance->DoUpdateAchievementCriteria(CRITERIA_TYPE_SCRIPT_EVENT_2, 46149); //Step 7. Final
                 me->DespawnOrUnsummon(3000);

--- a/src/server/scripts/Spells/spell_item.cpp
+++ b/src/server/scripts/Spells/spell_item.cpp
@@ -2540,7 +2540,7 @@ class spell_autographed_hearthstone_card : public SpellScript
                 }
 
                 player->PlayDistanceSound(47498, NULL);
-                player->SendPlaySpellVisualKit(0, 52852, 0);
+                player->SendPlaySpellVisualKit(52852, 0, 0);
                 break;
             case 2:
                 if (auto entry = sBroadcastTextStore.LookupEntry(90711))
@@ -2550,7 +2550,7 @@ class spell_autographed_hearthstone_card : public SpellScript
                 }
 
                 player->PlayDistanceSound(47499, NULL);
-                player->SendPlaySpellVisualKit(0, 52855, 0);
+                player->SendPlaySpellVisualKit(52855, 0, 0);
                 break;
             case 3:
                 if (auto entry = sBroadcastTextStore.LookupEntry(90712))
@@ -2560,7 +2560,7 @@ class spell_autographed_hearthstone_card : public SpellScript
                 }
 
                 player->PlayDistanceSound(47500, NULL);
-                player->SendPlaySpellVisualKit(0, 52856, 0);
+                player->SendPlaySpellVisualKit(52856, 0, 0);
                 break;
             case 4:
                 if (auto entry = sBroadcastTextStore.LookupEntry(90715))
@@ -2570,7 +2570,7 @@ class spell_autographed_hearthstone_card : public SpellScript
                 }
 
                 player->PlayDistanceSound(47501, NULL);
-                player->SendPlaySpellVisualKit(0, 52857, 0);
+                player->SendPlaySpellVisualKit(52857, 0, 0);
                 break;
             }
         }

--- a/src/server/scripts/Spells/spell_paladin.cpp
+++ b/src/server/scripts/Spells/spell_paladin.cpp
@@ -258,7 +258,7 @@ class spell_pal_divine_storm : public SpellScriptLoader
             if (Unit* caster = GetCaster())
             {
                 if (!hasDivineTempest)
-                    caster->SendPlaySpellVisualKit(0, 73892);
+                    caster->SendPlaySpellVisualKit(73892, 0);
             }
         }
 


### PR DESCRIPTION
The core was incorrectly using kit type instead of kit rec id/spellVisualKitId, which explains the incorrect packet order.

- Packet order has been fixed.
- All calls to `SendPlaySpellVisualKit` have been updated to properly pass spellVisualKitId.
  - Verify with paladin spell https://www.wowhead.com/spell=53385/divine-storm
- `smart_scripts` table data has been updated so `SMART_ACTION_PLAY_SPELL_VISUAL_KIT` uses spellVisualKitId instead of kitType.
  - `.go c 14525514` https://www.wowhead.com/npc=88859/elya-azuremoon
  - `.gm on`
  - select dialog option to see spell visual kit
- `spell_visual_kit` table data has been updated to use `KitRecID` instead of `KitType`.
  - verify with `.cast 181765` - player will briefly raise hand