### PR TITLE
Core/GameObject: reset to spawn game object state and fix interaction

### DIFF
--- a/src/server/game/AI/CoreAI/GameObjectAI.h
+++ b/src/server/game/AI/CoreAI/GameObjectAI.h
@@ -45,7 +45,7 @@ class GameObjectAI
         static int Permissible(GameObject const* go);
 
         virtual bool GossipUse(Player* /*player*/) { return false; }
-        virtual bool GossipHello(Player* /*player*/) { return false; }
+        virtual bool GossipHello(Player* /*player*/, bool /*isUse*/) { return false; }
         virtual bool GossipSelect(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/) { return false; }
         virtual bool GossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, char const* /*code*/) { return false; }
         virtual bool QuestAccept(Player* /*player*/, Quest const* /*quest*/) { return false; }

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -1032,7 +1032,7 @@ SmartScript* SmartGameObjectAI::GetScript()
 }
 
 // Called when a player opens a gossip dialog with the gameobject.
-bool SmartGameObjectAI::GossipHello(Player* player)
+bool SmartGameObjectAI::GossipHello(Player* player, bool /*isUse*/)
 {
     TC_LOG_DEBUG("scripts.ai", "SmartGameObjectAI::GossipHello");
     GetScript()->ProcessEventsFor(SMART_EVENT_GOSSIP_HELLO, player, 0, 0, false, nullptr, go);

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -249,7 +249,7 @@ class SmartGameObjectAI : public GameObjectAI
         SmartScript* GetScript();
         static int Permissible(const GameObject* g);
 
-        bool GossipHello(Player* player) override;
+        bool GossipHello(Player* player, bool isUse) override;
         bool GossipSelect(Player* player, uint32 sender, uint32 action) override;
         bool GossipSelectCode(Player* /*player*/, uint32 /*sender*/, uint32 /*action*/, const char* /*code*/) override;
         bool QuestAccept(Player* player, Quest const* quest) override;

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -2703,11 +2703,6 @@ void GameObject::SetLootState(LootState state, Unit* unit)
 
 void GameObject::SetGoState(GOState state)
 {
-    if (this->GetEntry() == 191588 && state == GO_STATE_ACTIVE)
-    {
-        TC_LOG_ERROR("server.loading", "SET GO STATE: %u", state);
-    }
-
     SetByteValue(GAMEOBJECT_FIELD_BYTES_1, GAMEOJBECT_BYTES_0_STATE, state);
 
     sScriptMgr->OnGameObjectStateChanged(this, state);

--- a/src/server/game/Entities/GameObject/GameObject.cpp
+++ b/src/server/game/Entities/GameObject/GameObject.cpp
@@ -49,7 +49,7 @@
 #include "World.h"
 
 GameObject::GameObject() : WorldObject(false), m_groupLootTimer(0), m_model(nullptr), m_goValue(), m_spellId(0), m_respawnTime(0), m_respawnDelayTime(300),
-m_lootState(GO_NOT_READY), m_spawnedByDefault(true), m_cooldownTime(0), m_ritualOwner(nullptr), m_usetimes(0), m_DBTableGuid(0), m_goInfo(nullptr),
+m_lootState(GO_NOT_READY), m_spawnedByDefault(true), m_cooldownTime(0), m_prevGoState(GO_STATE_ACTIVE), m_ritualOwner(nullptr), m_usetimes(0), m_DBTableGuid(0), m_goInfo(nullptr),
 m_goData(nullptr), m_manual_anim(false), m_isDynActive(false), m_onUse(false), m_actionVector(nullptr), m_AI(nullptr)
 {
     m_valuesCount = GAMEOBJECT_END;
@@ -294,6 +294,7 @@ bool GameObject::Create(ObjectGuid::LowType guidlow, uint32 name_id, Map* map, u
 
     // GAMEOBJECT_FIELD_BYTES_1, index at 0, 1, 2 and 3
     SetGoType(GameobjectTypes(goinfo->type));
+    m_prevGoState = go_state;
     SetGoState(go_state);
     SetGoArtKit(artKit);
     SetGoAnimProgress(animprogress);
@@ -1477,7 +1478,9 @@ void GameObject::ResetDoorOrButton()
     if (m_lootState == GO_READY || m_lootState == GO_JUST_DEACTIVATED)
         return;
 
-    SwitchDoorOrButton(false);
+    RemoveFlag(GAMEOBJECT_FIELD_FLAGS, GO_FLAG_IN_USE);
+    SetGoState(m_prevGoState);
+
     SetLootState(GO_JUST_DEACTIVATED);
     m_cooldownTime = 0;
 }
@@ -2700,6 +2703,11 @@ void GameObject::SetLootState(LootState state, Unit* unit)
 
 void GameObject::SetGoState(GOState state)
 {
+    if (this->GetEntry() == 191588 && state == GO_STATE_ACTIVE)
+    {
+        TC_LOG_ERROR("server.loading", "SET GO STATE: %u", state);
+    }
+
     SetByteValue(GAMEOBJECT_FIELD_BYTES_1, GAMEOJBECT_BYTES_0_STATE, state);
 
     sScriptMgr->OnGameObjectStateChanged(this, state);

--- a/src/server/game/Entities/GameObject/GameObject.h
+++ b/src/server/game/Entities/GameObject/GameObject.h
@@ -324,6 +324,8 @@ class GameObject : public WorldObject, public GridObject<GameObject>, public Map
         bool        m_spawnedByDefault;
         time_t      m_cooldownTime;                         // used as internal reaction delay time store (not state change reaction).
                                                             // For traps this: spell casting cooldown, for doors/buttons: reset time.
+        GOState     m_prevGoState;                          // What state to set whenever resetting
+
         GuidSet m_SkillupList;
 
         Player* m_ritualOwner;                              // used for GAMEOBJECT_TYPE_RITUAL where GO is not summoned (no owner)

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -189,7 +189,7 @@ void WorldSession::HandleGameobjectReportUse(WorldPackets::GameObject::GameObjRe
             go->Use(_player);
             break;
         default:
-            go->AI()->GossipHello(_player);
+            go->AI()->GossipHello(_player, false);
             break;
     }
     _player->UpdateAchievementCriteria(CRITERIA_TYPE_USE_GAMEOBJECT, go->GetEntry());

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3423,7 +3423,7 @@ void Spell::SendLoot(ObjectGuid const& guid, LootType loottype)
         if (sScriptMgr->OnGossipHello(player, gameObjTarget))
             return;
 
-        if (gameObjTarget->AI()->GossipHello(player))
+        if (gameObjTarget->AI()->GossipHello(player, true))
             return;
 
         switch (gameObjTarget->GetGoType())

--- a/src/server/scripts/Draenor/dark_portal.cpp
+++ b/src/server/scripts/Draenor/dark_portal.cpp
@@ -427,8 +427,11 @@ public:
             SOUTH_SCENE = 159127,
             EASTERN_SCENE = 159126
         };
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (go->GetEntry() == 229353)
             {
                 player->CastSpell(player, EASTERN_SCENE, true);
@@ -1411,8 +1414,11 @@ public:
             SPELL_CINEMA = 176159,
 
         };
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetQuestStatus(34445) == QUEST_STATUS_INCOMPLETE)
                 player->CastSpell(player, SPELL_CINEMA, true);
             return false;

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -320,24 +320,14 @@ class go_acherus_soul_prison : public GameObjectScript
 public:
     go_acherus_soul_prison() : GameObjectScript("go_acherus_soul_prison") { }
 
-    bool OnGossipHello(Player* player, GameObject* go) override
-    {
-        if (Creature* anchor = go->FindNearestCreature(29521, 15))
-            if (ObjectGuid prisonerGUID = anchor->AI()->GetGUID())
-                if (Creature* prisoner = Creature::GetCreature(*player, prisonerGUID))
-                    CAST_AI(npc_unworthy_initiate::npc_unworthy_initiateAI, prisoner->AI())->EventStart(anchor, player);
-
-        return false;
-    }
-
     struct go_acherus_soul_prisonAI : public GameObjectAI
     {
         go_acherus_soul_prisonAI(GameObject* go) : GameObjectAI(go) { }
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
-            if (player->GetQuestStatus(12848) != QUEST_STATUS_INCOMPLETE || !player->HasItemCount(40732, 1))
-                return false;
+            if (!isUse)
+                return true;
 
             if (Creature* anchor = go->FindNearestCreature(29521, 15))
                 if (ObjectGuid prisonerGUID = anchor->AI()->GetGUID())

--- a/src/server/scripts/Legion/mardum.cpp
+++ b/src/server/scripts/Legion/mardum.cpp
@@ -49,8 +49,11 @@ public:
             SCENE = 191677,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             /*
 
             ServerToClient: SMSG_PLAY_SCENE (0x2651) Length: 34 ConnIdx: 0 Time: 02/22/2016 12:57:13.116 Number: 11210
@@ -246,8 +249,11 @@ public:
             SCENE = 189261,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             /*
             ClientToServer: CMSG_GAME_OBJ_REPORT_USE (0x34DE) Length: 15 ConnIdx: 2 Time: 02/06/2016 22:39:25.012 Number: 16325
             GameObjectGUID: Full: 0x2C2090B920EEB5C00000100001364D15; HighType: GameObject; Low: 20335893; Map: 1481; Entry: 244439;
@@ -311,8 +317,11 @@ public:
                 return true;
             return false;
         }
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetReqKillOrCastCurrentCount(QUEST, go->GetEntry()))
                 return true;
 
@@ -767,8 +776,11 @@ public:
             QUEST = 38759,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             std::map<uint32, uint32> _data;
             _data[242989] = 94400;
             _data[244916] = 94377;
@@ -883,8 +895,11 @@ public:
             return false;
         }
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetReqKillOrCastCurrentCount(QUEST, CREDIT) || !player->GetReqKillOrCastCurrentCount(QUEST, CREDIT_REQUARE))
                 return true;
 
@@ -922,8 +937,11 @@ public:
             CREDIT = 100722,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetQuestStatus(QUEST) == QUEST_STATUS_INCOMPLETE)
             {
                 player->KilledMonsterCredit(CREDIT);
@@ -1071,8 +1089,11 @@ public:
             CREDIT = 94407,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetReqKillOrCastCurrentCount(QUEST, CREDIT))
                 return true;
 
@@ -1383,8 +1404,11 @@ public:
             CREDIT = 94407,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             uint32 credit1 = 0;
             uint32 credit2 = 0;
 
@@ -2052,8 +2076,11 @@ public:
             CREDIT = 100651,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetReqKillOrCastCurrentCount(QUEST, CREDIT))
                 return true;
 

--- a/src/server/scripts/Legion/warden_prison.cpp
+++ b/src/server/scripts/Legion/warden_prison.cpp
@@ -24,8 +24,11 @@ public:
             QUEST = 38690,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             for (int32 i = 0; i < sizeof(q38690); ++i)
             {
                 if (!player->GetReqKillOrCastCurrentCount(QUEST, q38690[i]))
@@ -707,8 +710,11 @@ public:
             CREDIT = 100166,
         };
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->GetQuestStatus(QUEST) == QUEST_STATUS_INCOMPLETE)
             {
                 player->CastSpell(player, 226867);

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_halion.cpp
@@ -1298,8 +1298,11 @@ class go_twilight_portal : public GameObjectScript
                 }
             }
 
-            bool GossipHello(Player* player) override
+            bool GossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 if (_spellId != 0)
                     player->CastSpell(player, _spellId, true);
                 return true;

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_algalon_the_observer.cpp
@@ -878,8 +878,11 @@ class go_celestial_planetarium_access : public GameObjectScript
             {
             }
 
-            bool GossipHello(Player* player) override
+            bool GossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 // Start Algalon event
                 go->SetFlag(GAMEOBJECT_FIELD_FLAGS, GO_FLAG_IN_USE);
                 /* _events.ScheduleEvent(EVENT_DESPAWN_CONSOLE, 5000);

--- a/src/server/scripts/Scenario/Artifacts/DemonHunter/Vengeance/DH_vengeance_art_scenario.cpp
+++ b/src/server/scripts/Scenario/Artifacts/DemonHunter/Vengeance/DH_vengeance_art_scenario.cpp
@@ -131,8 +131,11 @@ public:
     {
         go_portal_fel_soulAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (InstanceScript* instance = player->GetInstanceScript())
                 if (instance->getScenarionStep() == DATA_STAGE_2)
                 {

--- a/src/server/scripts/Scenario/Artifacts/Monk/Shey-lun/Sheylun.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Monk/Shey-lun/Sheylun.cpp
@@ -486,8 +486,11 @@ public:
     {
         go_sheylun_crateAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (Creature* mob = go->FindNearestCreature(101882, 7.0f, true))
                 mob->AI()->DoAction(true);
             if (Creature* mob = go->FindNearestCreature(102063, 7.0f, true))

--- a/src/server/scripts/Scenario/Artifacts/Priest/Tuure/Tuure.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Priest/Tuure/Tuure.cpp
@@ -660,8 +660,11 @@ public:
     {
         go_tuure_crateAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             player->UpdateAchievementCriteria(CRITERIA_TYPE_SCRIPT_EVENT_2, 50633);
             if (Creature* boja = player->FindNearestCreature(106253, 60.0f, true))
             {

--- a/src/server/scripts/Scenario/Artifacts/Rogue/FangsoftheDevourer/Devourer.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Rogue/FangsoftheDevourer/Devourer.cpp
@@ -237,8 +237,11 @@ public:
     {
         go_devourer_miscAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (player->HasItemCount(136802, 1))
             {
                 uint32 criteria = 0;

--- a/src/server/scripts/Scenario/Artifacts/Rogue/Kingslayers/Kingslayers.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Rogue/Kingslayers/Kingslayers.cpp
@@ -321,8 +321,11 @@ public:
     {
         go_kingslayers_doorAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             //           if (InstanceScript *script = player->GetInstanceScript())
             {
                 //     if (script->getScenarionStep() == 5)

--- a/src/server/scripts/Scenario/Artifacts/Warrior/Warswords/Warswords.cpp
+++ b/src/server/scripts/Scenario/Artifacts/Warrior/Warswords/Warswords.cpp
@@ -17,8 +17,11 @@ public:
     {
         go_mystic_bonfireAI(GameObject* go) : GameObjectAI(go) {}
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (InstanceScript* script = go->GetInstanceScript())
                 if (script->getScenarionStep() == 0)
                 {
@@ -58,8 +61,11 @@ public:
 
         bool check;
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (check)
                 return false;
 

--- a/src/server/scripts/Scenario/AssaultBrokenShore/AssaultBrokenShore.cpp
+++ b/src/server/scripts/Scenario/AssaultBrokenShore/AssaultBrokenShore.cpp
@@ -427,8 +427,11 @@ public:
         go_bs_demoic_gatesAI(GameObject* go) : GameObjectAI(go){}
 
 
-        bool GossipHello(Player* player) override
+        bool GossipHello(Player* player, bool isUse) override
         {
+            if (!isUse)
+                return true;
+
             if (InstanceScript* instance = go->GetInstanceScript())
             {
                 if (instance->getScenarionStep() < 5)

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -957,12 +957,11 @@ class go_soulwell : public GameObjectScript
                 _stoneId = spellInfo->Effects[EFFECT_0]->ItemType;
             }
 
-            /// Due to the fact that this GameObject triggers CMSG_GAMEOBJECT_USE
-            /// _and_ CMSG_GAMEOBJECT_REPORT_USE, this GossipHello hook is called
-            /// twice. The script's handling is fine as it won't remove two charges
-            /// on the well. We have to find how to segregate REPORT_USE and USE.
-            bool GossipHello(Player* player) override
+            bool GossipHello(Player* player, bool isUse) override
             {
+                if (!isUse)
+                    return true;
+
                 Unit* owner = go->GetOwner();
                 if (_stoneSpell == 0 || _stoneId == 0)
                     return true;


### PR DESCRIPTION
**Changes proposed:**

- From https://github.com/TrinityCore/TrinityCore/commit/8a3f053a2f82460cf5d856404f6fcaf4b7eb44aa
  - Reset game object to original state from DB instead of toggling from whatever current state we have
- From https://github.com/TrinityCore/TrinityCore/commit/b539ac6afafbddcb75855511d66d97bbc2e95c30
  - Add `isUse` param to game object gossip hello to disambiguate `CMSG_GAME_OBJ_REPORT_USE` and `CMSG_GAME_OBJ_USE`
  - This makes unlocking the soul prison no longer an instant cast - now you can actually see the cast bar for https://www.wowhead.com/spell=54669/unlocking-soul-prison

**Issues addressed:**

Closes #133 


**Tests performed:**

- All Acherus Soul Prison tooltips now correctly show the key name
- Unlocking a soul prison requires the key
- The unlock spell is properly displayed
