### PR TITLE
Core/Quest: Death Comes from On High (part 1)

### DIFF
--- a/sql/updates/world/2024_11_03_fix_eye_of_acherus_flight.sql
+++ b/sql/updates/world/2024_11_03_fix_eye_of_acherus_flight.sql
@@ -1,0 +1,3 @@
+--
+-- hack? not sure how other cores work without this
+UPDATE `creature_template_movement` SET `Flight` = 2 WHERE `CreatureId` = 28511;

--- a/sql/updates/world/2024_11_03_fix_eye_of_acherus_flight.sql
+++ b/sql/updates/world/2024_11_03_fix_eye_of_acherus_flight.sql
@@ -1,3 +1,15 @@
 --
 -- hack? not sure how other cores work without this
 UPDATE `creature_template_movement` SET `Flight` = 2 WHERE `CreatureId` = 28511;
+
+-- fix action bar
+DELETE FROM `creature_template_spell` WHERE `entry` = 28511;
+UPDATE `creature_template` SET `spell1` = 51859, `spell2` = 51904, `spell3` = 52006, `spell4` = 0, `spell5` = 52694, `spell6` = 0, `spell7` = 0, `spell8` = 0 WHERE `entry` = 28511;
+
+-- fix recall spell
+DELETE FROM `spell_script_names` WHERE `spell_id` = 52694;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (52694, 'spell_q12641_recall_eye_of_acherus');
+
+-- fix siphon spell
+DELETE FROM `spell_script_names` WHERE `spell_id` = 51858;
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (51858, 'spell_q12641_death_comes_from_on_high');

--- a/src/server/game/Anticheat/Anticheat.cpp
+++ b/src/server/game/Anticheat/Anticheat.cpp
@@ -1043,10 +1043,10 @@ bool PlayerCheatData::HandleCustomAnticheatTests(uint32 opcode, MovementInfo& mo
 {
     // TODO These checks are unreliable and should be implemented in other way
 
-    if (!me->m_mover->IsPlayer())
+    if (!me->GetUnitBeingMoved()->IsPlayer())
         return true;
 
-    Player* mover = me->m_mover->ToPlayer();
+    Player* mover = me->GetUnitBeingMoved()->ToPlayer();
 
     /* teleport hack check */
     if (!mover->m_transport && !mover->m_movementInfo.transport.Guid && !mover->isInFlight())

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -857,7 +857,7 @@ bool Creature::UpdateEntry(uint32 entry, uint32 team, const CreatureData* data)
 void Creature::UpdateMovementFlags()
 {
     // Do not update movement flags if creature is controlled by a player (charm/vehicle)
-    if (m_ControlledByPlayer)
+    if (m_playerMovingMe)
         return;
 
 //    // Creatures with CREATURE_FLAG_EXTRA_NO_MOVE_FLAGS_UPDATE should control MovementFlags in your own scripts

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -73,4 +73,6 @@ struct TC_GAME_API CreatureMovementData
     std::string ToString() const;
 };
 
+const uint32 MAX_CREATURE_SPELLS = 8;
+
 #endif

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -322,6 +322,8 @@ class Object
         void ForceValuesUpdateAtIndex(uint32);
         
         bool IsPlayer() const { return GetTypeId() == TYPEID_PLAYER; }
+        static Player* ToPlayer(Object* o) { return o ? o->ToPlayer() : nullptr; }
+        static Player const* ToPlayer(Object const* o) { return o ? o->ToPlayer() : nullptr; }
         Player* ToPlayer() { if (IsPlayer()) return reinterpret_cast<Player*>(this); return nullptr; }
         Player const* ToPlayer() const { if (IsPlayer()) return reinterpret_cast<Player const*>(this); return nullptr; }
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -351,8 +351,8 @@ m_achievementMgr(sf::safe_ptr<AchievementMgr<Player>>(this))
 
     m_killPoints = 0.0f;
 
-    m_mover = this;
-    m_movedPlayer = this;
+    m_unitMovedByMe = this;
+    m_playerMovingMe = this;
     m_seer = this;
 
     m_contestedPvPTimer = 0;
@@ -29455,7 +29455,7 @@ bool Player::IsNeverVisible(WorldObject const* /*seer*/) const
 bool Player::CanAlwaysSee(WorldObject const* obj) const
 {
     // Always can see self
-    if (m_mover == obj)
+    if (GetUnitBeingMoved() == obj)
         return true;
 
     ObjectGuid guid = GetGuidValue(PLAYER_FIELD_FARSIGHT_OBJECT);
@@ -29964,6 +29964,8 @@ void Player::SendInitialPacketsBeforeAddToMap(bool login)
 
         activeGlyphs.IsFullUpdate = true;
         SendDirectMessage(activeGlyphs.Write());
+
+        SetMovedUnit(this);
     }
 }
 
@@ -30079,8 +30081,6 @@ void Player::SendInitialPacketsAfterAddToMap(bool login)
     if (uint32 instanceId = inst && InInstance() ? inst->GetInstanceId() : 0)
         if (Scenario* progress = sScenarioMgr->GetScenario(instanceId))
             progress->SendStepUpdate(this, true);
-
-    SetMover(this);
 
     if (login)
     {
@@ -31440,7 +31440,7 @@ void Player::SetClientControl(Unit* target, bool allowMove)
             SetViewpoint(target, true);
     }
 
-    SetMover(target);
+    SetMovedUnit(target);
 }
 
 void Player::UpdateZoneDependentAuras(uint32 newZone)
@@ -35223,20 +35223,6 @@ void Player::SendMovementSetCollisionHeight(float height, uint8 Reason)
     SendDirectMessage(setCollisionHeight.Write());
 }
 
-void Player::SetMover(Unit* target)
-{
-    if (!target || (target != this && !target->IsInWorld()))
-        return;
-
-    m_mover->m_movedPlayer = nullptr;
-    m_mover = target;
-    m_mover->m_movedPlayer = this;
-
-    WorldPackets::Movement::MoveSetActiveMover packet;
-    packet.MoverGUID = target->GetGUID();
-    SendDirectMessage(packet.Write());
-}
-
 void Player::ShowNeutralPlayerFactionSelectUI()
 {
     SendDirectMessage(WorldPackets::Misc::NullSMsg(SMSG_SHOW_NEUTRAL_PLAYER_FACTION_SELECT_UI).Write());
@@ -36124,7 +36110,7 @@ void Player::SendRaidGroupOnlyMessage(RaidGroupReason reason, int32 delay) const
 
 void Player::CastSpellInQueue()
 {
-    Unit* mover = m_mover;
+    Unit* mover = GetUnitBeingMoved();
     if (mover != this && mover->IsPlayer())
     {
         TC_LOG_ERROR("network", "WORLD: mover != _player id %u", m_spellInQueue.CastData->SpellID);

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -2863,7 +2863,6 @@ class Player : public Unit, public GridObject<Player>
         /*********************************************************/
         /***                 VARIOUS SYSTEMS                   ***/
         /*********************************************************/
-        Unit* m_mover;
         WorldObject* m_seer;
 
         void UpdateFallInformationIfNeed(MovementInfo const& minfo, uint16 opcode);
@@ -2871,8 +2870,6 @@ class Player : public Unit, public GridObject<Player>
         void HandleFall(MovementInfo const& movementInfo);
 
         void SetClientControl(Unit* target, bool allowMove);
-
-        void SetMover(Unit* target);
 
         void SetSeer(WorldObject* target) { m_seer = target; }
         void SetViewpoint(WorldObject* target, bool apply);

--- a/src/server/game/Entities/Unit/CharmInfo.h
+++ b/src/server/game/Entities/Unit/CharmInfo.h
@@ -71,7 +71,7 @@ struct CharmInfo
     void InitPetActionBar();
     void InitEmptyActionBar(bool withAttack = true);
 
-    bool AddSpellToActionBar(SpellInfo const* spellInfo, ActiveStates newstate = ACT_DECIDE);
+    bool AddSpellToActionBar(SpellInfo const* spellInfo, ActiveStates newstate = ACT_DECIDE, uint8 preferredSlot = 0);
     bool RemoveSpellFromActionBar(uint32 spell_id);
     void LoadPetActionBar(std::string const& data);
     void SetSpellAutocast(SpellInfo const* spellInfo, bool state);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -22704,18 +22704,14 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
             case CHARM_TYPE_VEHICLE:
                 SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
                 charmer->ToPlayer()->SetClientControl(this, true);
-                charmer->ToPlayer()->SetMover(this);
-                charmer->ToPlayer()->SetViewpoint(this, true);
                 charmer->ToPlayer()->VehicleSpellInitialize();
                 break;
             case CHARM_TYPE_POSSESS:
-                AddUnitState(UNIT_STATE_POSSESSED);
                 SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
                 charmer->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL);
                 charmer->ToPlayer()->SetClientControl(this, true);
-                charmer->ToPlayer()->SetMover(this);
-                charmer->ToPlayer()->SetViewpoint(this, true);
                 charmer->ToPlayer()->PossessSpellInitialize();
+                AddUnitState(UNIT_STATE_POSSESSED);
                 break;
             case CHARM_TYPE_CHARM:
                 if (IsCreature() && charmer->getClass() == CLASS_WARLOCK)
@@ -22819,21 +22815,15 @@ void Unit::RemoveCharmedBy(Unit* charmer)
         switch (type)
         {
             case CHARM_TYPE_VEHICLE:
-                charmer->ToPlayer()->SetClientControl(charmer, true);
-                charmer->ToPlayer()->SetViewpoint(this, false);
                 charmer->ToPlayer()->SetClientControl(this, false);
-                if (IsPlayer())
-                    ToPlayer()->SetMover(this);
+                charmer->ToPlayer()->SetClientControl(charmer, true);
                 RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
                 break;
             case CHARM_TYPE_POSSESS:
-                charmer->ToPlayer()->SetClientControl(charmer, true);
-                charmer->ToPlayer()->SetViewpoint(this, false);
-                charmer->ToPlayer()->SetClientControl(this, false);
-                if (IsPlayer())
-                    ToPlayer()->SetMover(this);
-                charmer->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL);
                 ClearUnitState(UNIT_STATE_POSSESSED);
+                charmer->ToPlayer()->SetClientControl(this, false);
+                charmer->ToPlayer()->SetClientControl(charmer, true);
+                charmer->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL);
                 RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PLAYER_CONTROLLED);
                 break;
             case CHARM_TYPE_CHARM:

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -217,7 +217,7 @@ SpellNonMeleeDamage::SpellNonMeleeDamage(Unit* _attacker, Unit* _target, uint32 
 #ifdef _MSC_VER
 #pragma warning(disable:4355)
 #endif
-Unit::Unit(bool isWorldObject): WorldObject(isWorldObject), m_movedPlayer(nullptr), m_lastSanctuaryTime(0), IsAIEnabled(false), NeedChangeAI(false), m_ControlledByPlayer(false),
+Unit::Unit(bool isWorldObject): WorldObject(isWorldObject), m_unitMovedByMe(nullptr), m_playerMovingMe(nullptr), m_lastSanctuaryTime(0), IsAIEnabled(false), NeedChangeAI(false), m_ControlledByPlayer(false),
 movespline(new Movement::MoveSpline()), i_AI(nullptr), i_disabledAI(nullptr), m_AutoRepeatFirstCast(false), m_procDeep(0), m_castCounter(0), m_removedAurasCount(0), i_motionMaster(this),
 m_regenTimer{0}, isCasterPet{false}, m_ThreatManager(this), m_vehicle(nullptr), m_vehicleKit(nullptr), m_unitTypeMask(UNIT_MASK_NONE), m_rootTimes{0}, m_HostileRefManager(this), _delayInterruptFlag(0), _lastDamagedTime(0), damageTrackingTimer_(),
 playerDamageTaken_(), npcDamageTaken_()
@@ -15864,7 +15864,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
         }
     }
 
-    if (Player* playerMover = GetPlayerMover()) // unit controlled by a player.
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved())) // unit controlled by a player.
     {
         // Send notification to self
         WorldPackets::Movement::MoveSetSpeed selfpacket(moveTypeToOpcode[mtype][1]);
@@ -17492,21 +17492,16 @@ void Unit::CleanupsBeforeDelete(bool finalCleanup)
     WorldObject::CleanupsBeforeDelete(finalCleanup);
 }
 
-Unit* Unit::GetMover() const
- {
-     if (Player const* player = ToPlayer())
-         return player->m_mover;
+void Unit::SetMovedUnit(Unit* target)
+{
+    m_unitMovedByMe->m_playerMovingMe = nullptr;
+    m_unitMovedByMe = ASSERT_NOTNULL(target);
+    m_unitMovedByMe->m_playerMovingMe = ASSERT_NOTNULL(ToPlayer());
 
-     return nullptr;
- }
- 
- Player* Unit::GetPlayerMover() const
- {
-     if (Unit* mover = GetMover())
-         return mover->ToPlayer();
-
-     return nullptr;
- }
+    WorldPackets::Movement::MoveSetActiveMover packet;
+    packet.MoverGUID = target->GetGUID();
+    ToPlayer()->SendDirectMessage(packet.Write());
+}
 
 void Unit::UpdateCharmAI()
 {
@@ -22505,7 +22500,7 @@ void Unit::SetRooted(bool apply)
 
     static OpcodeServer const rootOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_UNROOT, SMSG_MOVE_UNROOT}, {SMSG_MOVE_SPLINE_ROOT, SMSG_MOVE_ROOT}};
 
-    if (Player* playerMover = GetPlayerMover()) // unit controlled by a player.
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved())) // unit controlled by a player.
     {
         WorldPackets::Movement::MoveSetFlag packet(rootOpcodeTable[apply][1]);
         packet.MoverGUID = GetGUID();
@@ -22736,13 +22731,11 @@ bool Unit::SetCharmedBy(Unit* charmer, CharmType type, AuraApplication const* au
             case CHARM_TYPE_CONVERT:
                 break;
         }
-    }else if (type == CHARM_TYPE_CONVERT)
+    }
+    else if (type == CHARM_TYPE_CONVERT)
     {
         if (ToPlayer())
-        {
             ToPlayer()->SetClientControl(charmer, true);
-            ToPlayer()->SetMover(charmer);
-        }
     }
 
     return true;
@@ -22844,13 +22837,11 @@ void Unit::RemoveCharmedBy(Unit* charmer)
             case CHARM_TYPE_CONVERT:
                 break;
         }
-    }else if (type == CHARM_TYPE_CONVERT)
+    }
+    else if (type == CHARM_TYPE_CONVERT)
     {
         if (ToPlayer())
-        {
             ToPlayer()->SetClientControl(charmer, false);
-            ToPlayer()->SetMover(this);
-        }
     }
 
     // a guardian should always have charminfo
@@ -23547,7 +23538,7 @@ void Unit::KnockbackFrom(float x, float y, float speedXY, float speedZ, Movement
     else if (Unit* charmer = GetCharmer())
     {
         player = charmer->ToPlayer();
-        if (player && player->m_mover != this)
+        if (player && player->GetUnitBeingMoved() != this)
             player = nullptr;
     }
 
@@ -24947,7 +24938,7 @@ bool Unit::SetDisableGravity(bool disable, bool isPlayer)
 
     static OpcodeServer const gravityOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_ENABLE_GRAVITY, SMSG_MOVE_ENABLE_GRAVITY}, {SMSG_MOVE_SPLINE_DISABLE_GRAVITY, SMSG_MOVE_DISABLE_GRAVITY}};
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(gravityOpcodeTable[disable][1]);
         packet.MoverGUID = GetGUID();
@@ -25031,7 +25022,7 @@ bool Unit::SetCanFly(bool enable)
     if (!enable && IsPlayer())
         ToPlayer()->SetFallInformation(0, GetPositionZ());
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(flyOpcodeTable[enable][1]);
         packet.MoverGUID = GetGUID();
@@ -25068,7 +25059,7 @@ bool Unit::SetWaterWalking(bool enable)
 
     static OpcodeServer const waterWalkingOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_SET_LAND_WALK, SMSG_MOVE_SET_LAND_WALK}, {SMSG_MOVE_SPLINE_SET_WATER_WALK, SMSG_MOVE_SET_WATER_WALK}};
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(waterWalkingOpcodeTable[enable][1]);
         packet.MoverGUID = GetGUID();
@@ -25104,7 +25095,7 @@ bool Unit::SetFeatherFall(bool enable)
 
     static OpcodeServer const featherFallOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_SET_NORMAL_FALL, SMSG_MOVE_SET_NORMAL_FALL}, {SMSG_MOVE_SPLINE_SET_FEATHER_FALL, SMSG_MOVE_SET_FEATHER_FALL}};
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(featherFallOpcodeTable[enable][1]);
         packet.MoverGUID = GetGUID();
@@ -25188,7 +25179,7 @@ bool Unit::SetHover(bool enable)
         { SMSG_MOVE_SPLINE_SET_HOVER, SMSG_MOVE_SET_HOVERING }
     };
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(hoverOpcodeTable[enable][1]);
         packet.MoverGUID = GetGUID();
@@ -25221,7 +25212,7 @@ bool Unit::SetCollision(bool disable)
 
     static OpcodeServer const collisionOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_ENABLE_COLLISION, SMSG_MOVE_ENABLE_COLLISION}, {SMSG_MOVE_SPLINE_DISABLE_COLLISION, SMSG_MOVE_DISABLE_COLLISION}};
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(collisionOpcodeTable[disable][1]);
         packet.MoverGUID = GetGUID();
@@ -25537,7 +25528,7 @@ bool Unit::SetCanDoubleJump(bool enable)
         SMSG_MOVE_ENABLE_DOUBLE_JUMP
     };
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(doubleJumpOpcodeTable[enable]);
         packet.MoverGUID = GetGUID();
@@ -25581,7 +25572,7 @@ bool Unit::SetCanTransitionBetweenSwimAndFly(bool enable)
         RemoveExtraUnitMovementFlag(MOVEMENTFLAG2_CAN_SWIM_TO_FLY_TRANS);
 
     static OpcodeServer const swimToFlyTransOpcodeTable[2] = {SMSG_MOVE_DISABLE_TRANSITION_BETWEEN_SWIM_AND_FLY, SMSG_MOVE_ENABLE_TRANSITION_BETWEEN_SWIM_AND_FLY};
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(swimToFlyTransOpcodeTable[enable]);
         packet.MoverGUID = GetGUID();
@@ -25603,7 +25594,7 @@ bool Unit::SetCanTurnWhileFalling(bool enable)
         RemoveExtraUnitMovementFlag(MOVEMENTFLAG2_CAN_TURN_WHILE_FALLING);
 
     static OpcodeServer const canTurnWhileFallingOpcodeTable[2] = { SMSG_MOVE_UNSET_CAN_TURN_WHILE_FALLING, SMSG_MOVE_SET_CAN_TURN_WHILE_FALLING };
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         WorldPackets::Movement::MoveSetFlag packet(canTurnWhileFallingOpcodeTable[enable]);
         packet.MoverGUID = GetGUID();
@@ -25621,7 +25612,7 @@ void Unit::SendTeleportPacket(Position const& destPos)
     packet.movementInfo->RemoteTimeValid = true;
     Unit* broadcastSource = this;
 
-    if (Player* playerMover = GetPlayerMover())
+    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
         float x, y, z, o;
         destPos.GetPosition(x, y, z, o);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1651,9 +1651,11 @@ class Unit : public WorldObject
         CharmInfo* InitCharmInfo();
         void DeleteCharmInfo();
         void UpdateCharmAI();
-        Unit* GetMover() const;
-        Player* GetPlayerMover() const;
-        Player* m_movedPlayer;
+
+        void SetMovedUnit(Unit* target);
+        Unit* GetUnitBeingMoved() const { return m_unitMovedByMe; }
+        Player* GetPlayerMovingMe() const { return m_playerMovingMe; }
+
         SharedVisionList const& GetSharedVisionList() { return m_sharedVision; }
         void AddPlayerToVision(Player* player);
         void RemovePlayerFromVision(Player* player);
@@ -2560,6 +2562,9 @@ class Unit : public WorldObject
         float m_dmg_multiplier = 1.0f;
 
         float m_speed_rate[MAX_MOVE_TYPE];
+
+        Unit* m_unitMovedByMe; // only ever set for players, and only for direct client control
+        Player* m_playerMovingMe; // only set for direct client control (possess effects, vehicles and similar)
 
         uint32 m_overrideAutoattack[2];
 

--- a/src/server/game/Handlers/ItemHandler.cpp
+++ b/src/server/game/Handlers/ItemHandler.cpp
@@ -1070,7 +1070,7 @@ void WorldSession::HandleOpenItem(WorldPackets::Spells::OpenItem& packet)
 {
     Player* player = GetPlayer();
 
-    if (player->m_mover != player)
+    if (player->GetUnitBeingMoved() != player)
         return;
 
     Item* item = player->GetItemByPos(packet.Slot, packet.PackSlot);

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -433,8 +433,8 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPackets::Spells::PetCastSpell& 
 
     // TODO: need to check victim?
     SpellCastResult result;
-    if (caster->m_movedPlayer)
-        result = spell->CheckPetCast(caster->m_movedPlayer->GetSelectedUnit());
+    if (caster->GetPlayerMovingMe())
+        result = spell->CheckPetCast(caster->GetPlayerMovingMe()->GetSelectedUnit());
     else
         result = spell->CheckPetCast(nullptr);
     if (result == SPELL_CAST_OK)

--- a/src/server/game/Handlers/SpellHandler.cpp
+++ b/src/server/game/Handlers/SpellHandler.cpp
@@ -35,7 +35,7 @@ void WorldSession::HandleUseItemOpcode(WorldPackets::Spells::ItemUse& cast)
     Player* pUser = _player;
 
     // ignore for remote control state
-    if (pUser->m_mover != pUser)
+    if (pUser->GetUnitBeingMoved() != pUser)
         return;
 
     // client provided targets
@@ -152,7 +152,7 @@ void WorldSession::HandleUseItemOpcode(WorldPackets::Spells::ItemUse& cast)
 
 void WorldSession::HandleGameObjectUse(WorldPackets::GameObject::GameObjectUse& packet)
 {
-    if (_player->m_mover != _player || !_player->CanContact() || _player->IsSpectator())
+    if (_player->GetUnitBeingMoved() != _player || !_player->CanContact() || _player->IsSpectator())
         return;
 
     if (GameObject* obj = GetPlayer()->GetMap()->GetGameObject(packet.Guid))
@@ -165,9 +165,9 @@ void WorldSession::HandleGameobjectReportUse(WorldPackets::GameObject::GameObjRe
     if (!go)
         return;
 
-    if (_player->m_mover != _player)
+    if (_player->GetUnitBeingMoved() != _player)
     {
-        if (!(_player->IsOnVehicle(_player->m_mover) || _player->IsMounted()))
+        if (!(_player->IsOnVehicle(_player->GetUnitBeingMoved()) || _player->IsMounted()))
             return;
 
         if (_player->NeedDismount() && !go->GetGOInfo()->IsUsableMounted())
@@ -211,7 +211,7 @@ void WorldSession::HandleGameobjectReportUse(WorldPackets::GameObject::GameObjRe
 
 void WorldSession::HandleCastSpellOpcode(WorldPackets::Spells::CastSpell& cast)
 {
-    Unit* mover = _player->m_mover;
+    Unit* mover = _player->GetUnitBeingMoved();
     if (mover != _player && mover->IsPlayer())
     {
         TC_LOG_ERROR("network", "WORLD: mover != _player id %u", cast.Cast.SpellID);
@@ -499,7 +499,7 @@ void WorldSession::HandleCancelAutoRepeatSpellOpcode(WorldPackets::Spells::Cance
 
 void WorldSession::HandleCancelChanneling(WorldPackets::Spells::CancelChannelling& packet)
 {
-    Unit* mover = _player->m_mover;
+    Unit* mover = _player->GetUnitBeingMoved();
     if (mover != _player && mover->IsPlayer())
         return;
 
@@ -512,7 +512,7 @@ void WorldSession::HandleTotemDestroyed(WorldPackets::Totem::TotemDestroyed& pac
     if (!player)
         return;
 
-    if (player->m_mover != player)
+    if (player->GetUnitBeingMoved() != player)
         return;
 
     ++packet.Slot;

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -238,7 +238,7 @@ void MotionMaster::MoveTargetedHome()
         if (target)
         {
             TC_LOG_DEBUG("misc", "Following %s (GUID: %lu)", target->IsPlayer() ? "player" : "creature", target->IsPlayer() ? target->GetGUIDLow() : static_cast<Creature*>(target)->GetDBTableGUIDLow());
-            if (!_owner->m_movedPlayer)
+            if (!_owner->GetPlayerMovingMe())
             {
                 TC_LOG_DEBUG("misc", "Following %s (GUID: %lu)", target->IsPlayer() ? "player" : "creature", target->IsPlayer() ? target->GetGUIDLow() : static_cast<Creature*>(target)->GetDBTableGUIDLow());
                 Mutate(new FollowMovementGenerator<Creature>(*target, PET_FOLLOW_DIST, float(PET_FOLLOW_ANGLE)), MOTION_SLOT_ACTIVE);

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -22,6 +22,7 @@
 #include "CreatureAISelector.h"
 #include "FleeingMovementGenerator.h"
 #include "FlightPathMovementGenerator.h"
+#include "GenericMovementGenerator.h"
 #include "HomeMovementGenerator.h"
 #include "IdleMovementGenerator.h"
 #include "MoveSpline.h"
@@ -795,6 +796,18 @@ void MotionMaster::MoveBackward(uint32 id, float x, float y, float z, float spee
     if (speed > 0.0f)
         init.SetVelocity(speed);
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_CONTROLLED);
+}
+
+void MotionMaster::LaunchMoveSpline(Movement::MoveSplineInit&& init, uint32 id/*= 0*/, MovementSlot slot/*= MOTION_SLOT_ACTIVE*/, MovementGeneratorType type/*= EFFECT_MOTION_TYPE*/)
+{
+    if (IsInvalidMovementGeneratorType(type))
+    {
+        TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::LaunchMoveSpline: '%s', tried to launch a spline with an invalid MovementGeneratorType: %u (Id: %u, Slot: %u)", _owner->GetGUID().ToString().c_str(), type, id, slot);
+        return;
+    }
+
+    TC_LOG_DEBUG("movement.motionmaster", "MotionMaster::LaunchMoveSpline: '%s', initiates spline Id: %u (Type: %u, Slot: %u)", _owner->GetGUID().ToString().c_str(), id, type, slot);
+    Mutate(new GenericMovementGenerator(std::move(init), type, id), slot);
 }
 
 /******************** Private methods ********************/

--- a/src/server/game/Movement/MotionMaster.h
+++ b/src/server/game/Movement/MotionMaster.h
@@ -33,6 +33,7 @@ class PathGenerator;
 
 namespace Movement
 {
+    class MoveSplineInit;
     struct SpellEffectExtraData;
 }
 
@@ -42,7 +43,7 @@ namespace Movement
 #define SPEED_CHARGE    42.0f
 
 // values 0 ... MAX_DB_MOTION_TYPE-1 used in DB
-enum MovementGeneratorType
+enum MovementGeneratorType : uint8
 {
     IDLE_MOTION_TYPE                = 0,                   // IdleMovementGenerator.h
     RANDOM_MOTION_TYPE              = 1,                   // RandomMovementGenerator.h
@@ -176,6 +177,7 @@ class MotionMaster
         void MoveRotate(uint32 time, RotateDirection direction, bool repeat = false);
         void MoveBackward(uint32 id, float x, float y, float z, float speed = 0.0f);
 
+        void LaunchMoveSpline(Movement::MoveSplineInit&& init, uint32 id = 0, MovementSlot slot = MOTION_SLOT_ACTIVE, MovementGeneratorType type = EFFECT_MOTION_TYPE);
     private:
         void pop();
         bool NeedInitTop() const;
@@ -197,5 +199,8 @@ class MotionMaster
         bool _initialize[MAX_MOTION_SLOT];
         uint8 _cleanFlag;
 };
+
+inline bool IsInvalidMovementGeneratorType(MovementGeneratorType const type) { return type == MAX_DB_MOTION_TYPE || type == MAX_MOTION_TYPE; }
+
 #endif
 

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "GenericMovementGenerator.h"
+#include "Creature.h"
+#include "CreatureAI.h"
+#include "MoveSpline.h"
+#include "ObjectAccessor.h"
+#include "Unit.h"
+
+void GenericMovementGenerator::Initialize(Unit& /*owner*/)
+{
+    _duration.Reset(_splineInit.Launch());
+}
+
+bool GenericMovementGenerator::Update(Unit& owner, uint32 diff)
+{
+    _duration.Update(diff);
+    if (_duration.Passed())
+        return false;
+
+    return !owner.movespline->Finalized();
+}
+
+void GenericMovementGenerator::Finalize(Unit& owner)
+{
+    MovementInform(owner);
+}
+
+void GenericMovementGenerator::MovementInform(Unit& owner)
+{
+    if (_arrivalSpellId)
+        owner.CastSpell(ObjectAccessor::GetUnit(owner, _arrivalSpellTargetGuid), _arrivalSpellId, true);
+
+    if (Creature* creature = owner.ToCreature())
+        if (creature->AI())
+            creature->AI()->MovementInform(_type, _pointId);
+}

--- a/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.h
+++ b/src/server/game/Movement/MovementGenerators/GenericMovementGenerator.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the TrinityCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TRINITY_GENERICMOVEMENTGENERATOR_H
+#define TRINITY_GENERICMOVEMENTGENERATOR_H
+
+#include "MovementGenerator.h"
+#include "MoveSplineInit.h"
+#include "Timer.h"
+
+class Unit;
+
+enum MovementGeneratorType : uint8;
+
+class GenericMovementGenerator : public MovementGenerator
+{
+    public:
+        explicit GenericMovementGenerator(Movement::MoveSplineInit&& splineInit, MovementGeneratorType type, uint32 id, uint32 arrivalSpellId = 0, ObjectGuid const& arrivalSpellTargetGuid = ObjectGuid::Empty)
+            : _splineInit(std::move(splineInit)), _type(type), _pointId(id), _duration(0), _arrivalSpellId(arrivalSpellId), _arrivalSpellTargetGuid(arrivalSpellTargetGuid) { }
+
+        void Initialize(Unit&) override;
+        void Finalize(Unit&) override;
+        void Reset(Unit&) override { }
+        bool Update(Unit&, uint32) override;
+        MovementGeneratorType GetMovementGeneratorType() const override { return _type; }
+
+    private:
+        void MovementInform(Unit&);
+
+        Movement::MoveSplineInit _splineInit;
+        MovementGeneratorType _type;
+        uint32 _pointId;
+        TimeTrackerSmall _duration;
+
+        uint32 _arrivalSpellId;
+        ObjectGuid _arrivalSpellTargetGuid;
+};
+
+#endif

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -4222,10 +4222,10 @@ void AuraEffect::HandleAuraModIncreaseFlightSpeed(AuraApplication const* aurApp,
         if (mode & AURA_EFFECT_HANDLE_SEND_FOR_CLIENT_MASK && (apply || (!target->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED) && !target->HasAuraType(SPELL_AURA_FLY))))
         {
             target->SetCanTransitionBetweenSwimAndFly(apply);
-            target->SetCanFly(apply);
 
-            if (!apply && !target->IsLevitating() && target->IsCreature())
-                target->GetMotionMaster()->MoveFall();
+            if (target->SetCanFly(apply))
+                if (!apply && !target->IsLevitating() && target->IsCreature())
+                    target->GetMotionMaster()->MoveFall();
         }
 
         //! Someone should clean up these hacks and remove it from this function. It doesn't even belong here.

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3365,7 +3365,7 @@ void Spell::EffectEnergize(SpellEffIndex effIndex)
     }
 
     if (m_spellInfo->Id == 144859) //Add CP after use old CP
-        m_caster->m_movedPlayer->SaveAddComboPoints(damage);
+        m_caster->GetPlayerMovingMe()->SaveAddComboPoints(damage);
 }
 
 void Spell::EffectEnergizePct(SpellEffIndex effIndex)

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1163,15 +1163,6 @@ void Spell::EffectDummy(SpellEffIndex effIndex)
                 case 207510: //Flame of Woe
                     m_caster->CastSpell(m_caster, 207509, true);
                     break;
-                case 51858:     //Q: Death Comes From On High ID 12641
-                    if (unitTarget &&
-                        (unitTarget->GetEntry() == 28543 ||
-                        unitTarget->GetEntry() == 28542 ||
-                        unitTarget->GetEntry() == 28525 ||
-                        unitTarget->GetEntry() == 28544))
-                        if (Player *plr = m_caster->GetCharmerOrOwnerPlayerOrPlayerItself())
-                            plr->KilledMonsterCredit(unitTarget->GetEntry(), unitTarget->GetGUID());
-                    break;
                 case 78640: // Deepstone Oil
                 {
                     if (m_caster->HasAuraType(SPELL_AURA_MOUNTED))

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -15,15 +15,17 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "CharmInfo.h"
+#include "CombatAI.h"
+#include "GameObjectAI.h"
+#include "MoveSplineInit.h"
+#include "ObjectMgr.h"
+#include "PassiveAI.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
+#include "ScriptedEscortAI.h"
 #include "ScriptedGossip.h"
 #include "Vehicle.h"
-#include "ObjectMgr.h"
-#include "ScriptedEscortAI.h"
-#include "CombatAI.h"
-#include "PassiveAI.h"
-#include "GameObjectAI.h"
 
 /*######
 ##Quest 12848
@@ -1096,89 +1098,120 @@ public:
 ## npc_eye_of_acherus
 ######*/
 
-class npc_eye_of_acherus : public CreatureScript
+enum EyeOfAcherus
 {
-public:
-    npc_eye_of_acherus() : CreatureScript("npc_eye_of_acherus") { }
+    SPELL_THE_EYE_OF_ACHERUS                = 51852,
+    SPELL_EYE_OF_ACHERUS_VISUAL             = 51892,
+    SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST       = 51923,
+    SPELL_EYE_OF_ACHERUS_FLIGHT             = 51890,
+    SPELL_ROOT_SELF                         = 51860,
 
-    CreatureAI* GetAI(Creature* _Creature) const
+    EVENT_ANNOUNCE_LAUNCH_TO_DESTINATION    = 1,
+    EVENT_UNROOT                            = 2,
+    EVENT_LAUNCH_TOWARDS_DESTINATION        = 3,
+    EVENT_GRANT_CONTROL                     = 4,
+
+    SAY_LAUNCH_TOWARDS_DESTINATION          = 0,
+    SAY_EYE_UNDER_CONTROL                   = 1,
+
+    POINT_NEW_AVALON                        = 1
+};
+
+static constexpr uint8 const EyeOfAcherusPathSize = 4;
+G3D::Vector3 const EyeOfAcherusPath[EyeOfAcherusPathSize] =
+{
+    { 2361.21f,  -5660.45f,  496.744f  },
+    { 2341.571f, -5672.797f, 538.3942f },
+    { 1957.4f,   -5844.1f,   273.867f  },
+    { 1758.01f,  -5876.79f,  166.867f  }
+};
+
+struct npc_eye_of_acherus : public ScriptedAI
+{
+    npc_eye_of_acherus(Creature* creature) : ScriptedAI(creature)
     {
-        return new npc_eye_of_acherusAI(_Creature);
+        creature->SetDisplayId(creature->GetCreatureTemplate()->Modelid[0]);
+        creature->SetReactState(REACT_PASSIVE);
+        if (creature->GetCharmInfo())
+            creature->GetCharmInfo()->InitPossessCreateSpells();
     }
 
-    struct npc_eye_of_acherusAI : public ScriptedAI
+    void InitializeAI() override
     {
-        npc_eye_of_acherusAI(Creature* c) : ScriptedAI(c)
+        DoCastSelf(SPELL_ROOT_SELF);
+        DoCastSelf(SPELL_EYE_OF_ACHERUS_VISUAL);
+        _events.ScheduleEvent(EVENT_ANNOUNCE_LAUNCH_TO_DESTINATION, 7s);
+    }
+
+    void OnCharmed(bool apply) override
+    {
+        if (!apply)
         {
-            me->setActive(true);
-            me->SetLevel(55); //else one hack
-            StartTimer = 1000;
-            Active = false;
+            me->GetCharmerOrOwner()->RemoveAurasDueToSpell(SPELL_THE_EYE_OF_ACHERUS);
+            me->GetCharmerOrOwner()->RemoveAurasDueToSpell(SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST);
         }
+    }
 
-        uint32 StartTimer;
-        bool Active;
+    void UpdateAI(uint32 diff) override
+    {
+        _events.Update(diff);
 
-        void Reset(){}
-        void AttackStart(Unit *) {}
-        void MoveInLineOfSight(Unit*) {}
-        void OnCharmed(bool /*apply*/)
+        while (uint32 eventId = _events.ExecuteEvent())
         {
-            //NOT DISABLE AI!
-        }
-
-        void JustDied(Unit*u)
-        {
-            if(!me || me->GetTypeId() != TYPEID_UNIT)
-                return;
-
-            Unit *target = me->GetCharmer();
-
-            if(!target || target->GetTypeId() != TYPEID_PLAYER)
-                return;
-
-            target->RemoveAurasDueToSpell(51852);
-            me->RemoveCharmedBy(NULL);
-
-            //me->DespawnOrUnsummon();
-        }
-
-        void MovementInform(uint32 uiType, uint32 uiPointId)
-        {
-            if (uiType != POINT_MOTION_TYPE && uiPointId == 0)
-                return;
-
-                const char* text = "The Eye of Acherus is in your control";
-                me->MonsterTextEmote(text, me->GetGUID(), true);
-                me->CastSpell(me, 51890, true);
-                //me->RemoveUnitMovementFlag(MOVEMENTFLAG_FLYING);
-                //me->AddUnitMovementFlag(MOVEMENTFLAG_WALKING);
-        }
-
-        void UpdateAI(uint32 uiDiff)
-        {
-            if(me->isCharmed())
+            switch (eventId)
             {
-                if (StartTimer < uiDiff && !Active)
+                case EVENT_ANNOUNCE_LAUNCH_TO_DESTINATION:
+                    if (Unit* owner = me->GetCharmerOrOwner())
+                        Talk(SAY_LAUNCH_TOWARDS_DESTINATION, owner->GetGUID());
+                    _events.ScheduleEvent(EVENT_UNROOT, 1s + 200ms);
+                    break;
+                case EVENT_UNROOT:
+                    me->RemoveAurasDueToSpell(SPELL_ROOT_SELF);
+                    DoCastSelf(SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST);
+                    _events.ScheduleEvent(EVENT_LAUNCH_TOWARDS_DESTINATION, 1s + 200ms);
+                    break;
+                case EVENT_LAUNCH_TOWARDS_DESTINATION:
                 {
-                    //me->CastSpell(me, 70889, true);
-                    //me->CastSpell(me, 51892, true);
-                    //me->SetPhaseMask(3, false);
-                    const char* text = "The Eye of Acherus launches towards its destination";
-                    me->MonsterTextEmote(text, me->GetGUID(), true);
-                    me->SetSpeed(MOVE_FLIGHT, 6.4f,true);
-                    me->AddUnitMovementFlag(MOVEMENTFLAG_FLYING);
-                    me->GetMotionMaster()->MovePoint(0, 1750.8276f, -5873.788f, 147.2266f);
-                    Active = true;
+                    Movement::MoveSplineInit init(*me);
+                    Movement::PointsArray path(EyeOfAcherusPath, EyeOfAcherusPath + EyeOfAcherusPathSize);
+                    init.MovebyPath(path);
+                    init.SetFly();
+                    if (Unit* owner = me->GetCharmerOrOwner())
+                        init.SetVelocity(owner->GetSpeed(MOVE_RUN));
+                    me->GetMotionMaster()->LaunchMoveSpline(std::move(init), POINT_NEW_AVALON, MOTION_SLOT_ACTIVE, POINT_MOTION_TYPE);
+                    break;
                 }
-                else StartTimer -= uiDiff;
+                case EVENT_GRANT_CONTROL:
+                    me->RemoveAurasDueToSpell(SPELL_ROOT_SELF);
+                    DoCastSelf(SPELL_EYE_OF_ACHERUS_FLIGHT);
+                    me->RemoveAurasDueToSpell(SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST);
+                    if (Unit* owner = me->GetCharmerOrOwner())
+                        Talk(SAY_EYE_UNDER_CONTROL, owner->GetGUID());
+                    break;
+                default:
+                    break;
             }
-            /*else
-            {
-                me->DespawnOrUnsummon();
-            }*/
         }
-    };
+    }
+
+    void MovementInform(uint32 movementType, uint32 pointId) override
+    {
+        if (movementType != POINT_MOTION_TYPE)
+            return;
+
+        switch (pointId)
+        {
+            case POINT_NEW_AVALON:
+                DoCastSelf(SPELL_ROOT_SELF);
+                _events.ScheduleEvent(EVENT_GRANT_CONTROL, 2s + 500ms);
+                break;
+            default:
+                break;
+        }
+    }
+
+private:
+    EventMap _events;
 };
 
 void AddSC_the_scarlet_enclave_c1()
@@ -1194,5 +1227,5 @@ void AddSC_the_scarlet_enclave_c1()
     //new npc_scarlet_ghoul();
     new npc_scarlet_miner();
     new npc_scarlet_miner_cart();
-    new npc_eye_of_acherus();
+    RegisterCreatureAI(npc_eye_of_acherus);
 }

--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -1167,6 +1167,10 @@ struct npc_eye_of_acherus : public ScriptedAI
                     break;
                 case EVENT_UNROOT:
                     me->RemoveAurasDueToSpell(SPELL_ROOT_SELF);
+
+                    // TODO: hack
+                    me->ClearUnitState(UNIT_STATE_ROOT);
+
                     DoCastSelf(SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST);
                     _events.ScheduleEvent(EVENT_LAUNCH_TOWARDS_DESTINATION, 1s + 200ms);
                     break;
@@ -1183,6 +1187,11 @@ struct npc_eye_of_acherus : public ScriptedAI
                 }
                 case EVENT_GRANT_CONTROL:
                     me->RemoveAurasDueToSpell(SPELL_ROOT_SELF);
+
+                    // TODO: hack
+                    me->SetSheath(SHEATH_STATE_MELEE);
+                    me->ClearUnitState(UNIT_STATE_ROOT);
+
                     DoCastSelf(SPELL_EYE_OF_ACHERUS_FLIGHT);
                     me->RemoveAurasDueToSpell(SPELL_EYE_OF_ACHERUS_FLIGHT_BOOST);
                     if (Unit* owner = me->GetCharmerOrOwner())
@@ -1203,6 +1212,10 @@ struct npc_eye_of_acherus : public ScriptedAI
         {
             case POINT_NEW_AVALON:
                 DoCastSelf(SPELL_ROOT_SELF);
+
+                // TODO: hack
+                me->AddUnitState(UNIT_STATE_ROOT);
+
                 _events.ScheduleEvent(EVENT_GRANT_CONTROL, 2s + 500ms);
                 break;
             default:

--- a/src/server/scripts/Spells/spell_quest.cpp
+++ b/src/server/scripts/Spells/spell_quest.cpp
@@ -582,6 +582,92 @@ class spell_q12634_despawn_fruit_tosser : public SpellScriptLoader
         }
 };
 
+enum DeathComesFromOnHigh
+{
+    SPELL_FORGE_CREDIT                  = 51974,
+    SPELL_TOWN_HALL_CREDIT              = 51977,
+    SPELL_SCARLET_HOLD_CREDIT           = 51980,
+    SPELL_CHAPEL_CREDIT                 = 51982,
+
+    NPC_NEW_AVALON_FORGE                = 28525,
+    NPC_NEW_AVALON_TOWN_HALL            = 28543,
+    NPC_SCARLET_HOLD                    = 28542,
+    NPC_CHAPEL_OF_THE_CRIMSON_FLAME     = 28544
+};
+
+// 51858 - Siphon of Acherus
+class spell_q12641_death_comes_from_on_high : public SpellScript
+{
+    PrepareSpellScript(spell_q12641_death_comes_from_on_high);
+
+    bool Validate(SpellInfo const* /*spellInfo*/) override
+    {
+        return ValidateSpellInfo(
+        {
+            SPELL_FORGE_CREDIT,
+            SPELL_TOWN_HALL_CREDIT,
+            SPELL_SCARLET_HOLD_CREDIT,
+            SPELL_CHAPEL_CREDIT
+        });
+    }
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        uint32 spellId = 0;
+
+        switch (GetHitCreature()->GetEntry())
+        {
+            case NPC_NEW_AVALON_FORGE:
+                spellId = SPELL_FORGE_CREDIT;
+                break;
+            case NPC_NEW_AVALON_TOWN_HALL:
+                spellId = SPELL_TOWN_HALL_CREDIT;
+                break;
+            case NPC_SCARLET_HOLD:
+                spellId = SPELL_SCARLET_HOLD_CREDIT;
+                break;
+            case NPC_CHAPEL_OF_THE_CRIMSON_FLAME:
+                spellId = SPELL_CHAPEL_CREDIT;
+                break;
+            default:
+                return;
+        }
+
+        GetCaster()->CastSpell(GetCaster(), spellId, true);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_q12641_death_comes_from_on_high::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+};
+
+enum Recall_Eye_of_Acherus
+{
+    THE_EYE_OF_ACHERUS = 51852
+};
+
+// 52694 - Recall Eye of Acherus
+class spell_q12641_recall_eye_of_acherus : public SpellScript
+{
+    PrepareSpellScript(spell_q12641_recall_eye_of_acherus);
+
+    void HandleDummy(SpellEffIndex /*effIndex*/)
+    {
+        if (Player* player = GetCaster()->GetCharmerOrOwner()->ToPlayer())
+        {
+            player->StopCastingCharm();
+            player->StopCastingBindSight();
+            player->RemoveAura(THE_EYE_OF_ACHERUS);
+        }
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_q12641_recall_eye_of_acherus::HandleDummy, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
 // http://www.wowhead.com/quest=12683 Burning to Help
 // 52308 Take Sputum Sample
 class spell_q12683_take_sputum_sample : public SpellScriptLoader
@@ -1736,6 +1822,8 @@ void AddSC_quest_spell_scripts()
     new spell_q11730_ultrasonic_screwdriver();
     new spell_q12459_seeds_of_natures_wrath();
     new spell_q12634_despawn_fruit_tosser();
+    RegisterSpellScript(spell_q12641_death_comes_from_on_high);
+    RegisterSpellScript(spell_q12641_recall_eye_of_acherus);
     new spell_q12683_take_sputum_sample();
     new spell_q12851_going_bearback();
     new spell_q12937_relief_for_the_fallen();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Goal was to improve movement in https://www.wowhead.com/quest=12641/death-comes-from-on-high
- `npc_eye_of_acherus` script ported from TC master
- Cleanup around client control/possession
- Enable flying
- Fix action bar buttons/order
- Fix recall spell on action bar
- Use spell script for siphon credit
- References
  - https://github.com/TrinityCore/TrinityCore/commit/bba4696de715b79b31e154d1a8e1597507812ece
  - https://github.com/TrinityCore/TrinityCore/commit/edc75831194bc2419e3abada47121fadf4b2aa8d
  - https://github.com/TrinityCore/TrinityCore/commit/b1721a65ee7595b99269d01cdccd7aa6557ab099
  - https://github.com/TrinityCore/TrinityCore/commit/eccb0ed3dac67a7463cc5c1ff5cf2cd3919e7a25

**Issues addressed:**

**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:**

- [ ] Core has no server-side spell support (`spell_dbc` or `serverside_spell` tables), so `SPELL_ROOT_SELF` (51860) is not implemented
- [ ] Phasing is incorrect
- [x] Manual control is still very slow and unable to move up or down
- [x] Some action bar buttons don't work


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
