### PR TITLE
Core/Spells: improve and cleanup some dk spell scripts

### DIFF
--- a/sql/updates/world/2024_11_04_death_knight_spell_scripts.sql
+++ b/sql/updates/world/2024_11_04_death_knight_spell_scripts.sql
@@ -1,0 +1,12 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (49998, 49576, 195182, 50842, 43265);
+
+INSERT INTO `spell_script_names` (spell_id, ScriptName)
+VALUES
+(49998, 'spell_dk_death_strike'),
+(49576, 'spell_dk_death_grip_initial'),
+(195182, 'spell_dk_marrowrend'),
+(50842, 'spell_dk_blood_boil'),
+(43265, 'spell_dk_death_and_decay');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 49998;

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -162,6 +162,46 @@ struct PlayerSpell
     bool disabled          : 1;                             // first rank has been learned in result talent learn but currently talent unlearned, save max learned ranks
 };
 
+enum TalentSpecialization // talent tabs
+{
+    TALENT_SPEC_MAGE_ARCANE             = 62,
+    TALENT_SPEC_MAGE_FIRE               = 63,
+    TALENT_SPEC_MAGE_FROST              = 64,
+    TALENT_SPEC_PALADIN_HOLY            = 65,
+    TALENT_SPEC_PALADIN_PROTECTION      = 66,
+    TALENT_SPEC_PALADIN_RETRIBUTION     = 70,
+    TALENT_SPEC_WARRIOR_ARMS            = 71,
+    TALENT_SPEC_WARRIOR_FURY            = 72,
+    TALENT_SPEC_WARRIOR_PROTECTION      = 73,
+    TALENT_SPEC_DRUID_BALANCE           = 102,
+    TALENT_SPEC_DRUID_CAT               = 103,
+    TALENT_SPEC_DRUID_BEAR              = 104,
+    TALENT_SPEC_DRUID_RESTORATION       = 105,
+    TALENT_SPEC_DEATHKNIGHT_BLOOD       = 250,
+    TALENT_SPEC_DEATHKNIGHT_FROST       = 251,
+    TALENT_SPEC_DEATHKNIGHT_UNHOLY      = 252,
+    TALENT_SPEC_HUNTER_BEASTMASTER      = 253,
+    TALENT_SPEC_HUNTER_MARKSMAN         = 254,
+    TALENT_SPEC_HUNTER_SURVIVAL         = 255,
+    TALENT_SPEC_PRIEST_DISCIPLINE       = 256,
+    TALENT_SPEC_PRIEST_HOLY             = 257,
+    TALENT_SPEC_PRIEST_SHADOW           = 258,
+    TALENT_SPEC_ROGUE_ASSASSINATION     = 259,
+    TALENT_SPEC_ROGUE_COMBAT            = 260,
+    TALENT_SPEC_ROGUE_SUBTLETY          = 261,
+    TALENT_SPEC_SHAMAN_ELEMENTAL        = 262,
+    TALENT_SPEC_SHAMAN_ENHANCEMENT      = 263,
+    TALENT_SPEC_SHAMAN_RESTORATION      = 264,
+    TALENT_SPEC_WARLOCK_AFFLICTION      = 265,
+    TALENT_SPEC_WARLOCK_DEMONOLOGY      = 266,
+    TALENT_SPEC_WARLOCK_DESTRUCTION     = 267,
+    TALENT_SPEC_MONK_BREWMASTER         = 268,
+    TALENT_SPEC_MONK_BATTLEDANCER       = 269,
+    TALENT_SPEC_MONK_MISTWEAVER         = 270,
+    TALENT_SPEC_DEMON_HUNTER_HAVOC      = 577,
+    TALENT_SPEC_DEMON_HUNTER_VENGEANCE  = 581
+};
+
 // Spell modifier (used for modify other spells)
 struct SpellModifier
 {

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -1029,8 +1029,13 @@ void Spell::SelectImplicitAreaTargets(SpellEffIndex effIndex, SpellImplicitTarge
             ASSERT(false && "Spell::SelectImplicitAreaTargets: received not implemented target reference type");
             return;
     }
+
     std::list<WorldObject*> targets;
-    float radius = m_spellInfo->GetEffect(effIndex, m_diffMode)->CalcRadius(m_caster) * m_spellValue->RadiusMod;
+    SpellEffectInfo const* effect = m_spellInfo->GetEffect(effIndex, m_diffMode);
+    if (!effect)
+        return;
+
+    float radius = effect->CalcRadius(m_caster) * m_spellValue->RadiusMod;
     if (radius <= 0)
     {
         if (m_caster->InInstance())
@@ -1047,7 +1052,7 @@ void Spell::SelectImplicitAreaTargets(SpellEffIndex effIndex, SpellImplicitTarge
 
     SearchAreaTargets(targets, radius, center, referer, targetType.GetObjectType(), targetType.GetCheckType(), m_spellInfo->Effects[effIndex]->ImplicitTargetConditions, allowTargetObjSize);
 
-    TC_LOG_DEBUG("spells", "Spell::SelectImplicitAreaTargets %u, radius %f, GetObjectType %u, targets count %zull, effIndex %i",
+    TC_LOG_DEBUG("spells", "Spell::SelectImplicitAreaTargets %u, radius %f, GetObjectType %u, targets count %zu, effIndex %i",
         m_spellInfo->Id, radius, targetType.GetObjectType(), targets.size(), effIndex);
 
     CallScriptObjectAreaTargetSelectHandlers(targets, effIndex, targetType.GetTarget());
@@ -1226,7 +1231,6 @@ void Spell::SelectImplicitAreaTargets(SpellEffIndex effIndex, SpellImplicitTarge
 void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplicitTargetInfo const& targetType)
 {
     SpellDestination dest(*m_caster);
-    //m_targets.SetDst(*m_caster);
 
     switch (targetType.GetTarget())
     {
@@ -1292,7 +1296,10 @@ void Spell::SelectImplicitCasterDestTargets(SpellEffIndex effIndex, SpellImplici
     }
 
     if (targetType.GetDirectionType() == TARGET_DIR_NONE)
+    {
+        m_targets.SetDst(dest);
         return;
+    }
 
     float dist = 0.0f;
     float angle = targetType.CalcDirectionAngle();

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -5005,16 +5005,6 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
                     AddPct(m_damage, aurEff->GetAmount());
             break;
         }
-        case 49998: // Death Strike
-        {
-            float pctDamage = m_caster->CanPvPScalar() ? m_spellInfo->GetEffect(EFFECT_2, m_diffMode)->CalcValue(_caster) / 2 : m_spellInfo->GetEffect(EFFECT_2, m_diffMode)->CalcValue(_caster);
-            int32 lastTime = m_spellInfo->GetEffect(EFFECT_3, m_diffMode)->CalcValue(_caster);
-            int32 pctHeal = m_spellInfo->GetEffect(EFFECT_4, m_diffMode)->CalcValue(_caster);
-            float bp = _caster->CountPctFromMaxHealth(pctHeal) + CalculatePct(_caster->GetDamageTakenInPastSecs(lastTime, true, true), pctDamage);
-
-            _caster->CastCustomSpell(_caster, 45470, &bp, nullptr, nullptr, false);
-            break;
-        }
         case 53: // Backstab
         {
             if (!unitTarget->HasInArc(static_cast<float>(M_PI/2), _caster))

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -26,6 +26,145 @@
 #include "SpellAuraEffects.h"
 #include "AreaTrigger.h"
 
+enum DeathKnightSpells
+{
+    SPELL_DK_ARMY_FLESH_BEAST_TRANSFORM         = 127533,
+    SPELL_DK_ARMY_GEIST_TRANSFORM               = 127534,
+    SPELL_DK_ARMY_NORTHREND_SKELETON_TRANSFORM  = 127528,
+    SPELL_DK_ARMY_SKELETON_TRANSFORM            = 127527,
+    SPELL_DK_ARMY_SPIKED_GHOUL_TRANSFORM        = 127525,
+    SPELL_DK_ARMY_SUPER_ZOMBIE_TRANSFORM        = 127526,
+    SPELL_DK_BLOOD_PLAGUE                       = 55078,
+    SPELL_DK_BLOOD_PRESENCE                     = 48263,
+    SPELL_DK_BLOOD_SHIELD_MASTERY               = 77513,
+    SPELL_DK_BLOOD_SHIELD_ABSORB                = 77535,
+    SPELL_DK_CHAINS_OF_ICE                      = 45524,
+    SPELL_DK_CORPSE_EXPLOSION_TRIGGERED         = 43999,
+    SPELL_DK_DEATH_AND_DECAY_DAMAGE             = 52212,
+    SPELL_DK_DEATH_AND_DECAY_SLOW               = 143375,
+    SPELL_DK_DEATH_COIL_BARRIER                 = 115635,
+    SPELL_DK_DEATH_COIL_DAMAGE                  = 47632,
+    SPELL_DK_DEATH_COIL_HEAL                    = 47633,
+    SPELL_DK_DEATH_GRIP                         = 49576,
+    SPELL_DK_DEATH_GRIP_PULL                    = 49575,
+    SPELL_DK_DEATH_GRIP_VISUAL                  = 55719,
+    SPELL_DK_DEATH_GRIP_TAUNT                   = 57603,
+    SPELL_DK_DEATH_STRIKE_HEAL                  = 45470,
+    SPELL_DK_DECOMPOSING_AURA                   = 199720,
+    SPELL_DK_DECOMPOSING_AURA_DAMAGE            = 199721,
+    SPELL_DK_ENHANCED_DEATH_COIL                = 157343,
+    SPELL_DK_FROST_FEVER                        = 55095,
+    SPELL_DK_GHOUL_EXPLODE                      = 47496,
+    SPELL_DK_GLYPH_OF_ABSORB_MAGIC              = 159415,
+    SPELL_DK_GLYPH_OF_ANTI_MAGIC_SHELL          = 58623,
+    SPELL_DK_GLYPH_OF_ARMY_OF_THE_DEAD          = 58669,
+    SPELL_DK_GLYPH_OF_DEATH_COIL                = 63333,
+    SPELL_DK_GLYPH_OF_DEATH_AND_DECAY           = 58629,
+    SPELL_DK_GLYPH_OF_FOUL_MENAGERIE            = 58642,
+    SPELL_DK_GLYPH_OF_REGENERATIVE_MAGIC        = 146648,
+    SPELL_DK_GLYPH_OF_RUNIC_POWER_TRIGGERED     = 159430,
+    SPELL_DK_GLYPH_OF_SWIFT_DEATH               = 146645,
+    SPELL_DK_GLYPH_OF_THE_GEIST                 = 58640,
+    SPELL_DK_GLYPH_OF_THE_SKELETON              = 146652,
+    SPELL_DK_IMPROVED_BLOOD_PRESENCE            = 50371,
+    SPELL_DK_IMPROVED_SOUL_REAPER               = 157342,
+    SPELL_DK_RUNIC_POWER_ENERGIZE               = 49088,
+    SPELL_DK_SCENT_OF_BLOOD                     = 49509,
+    SPELL_DK_SCENT_OF_BLOOD_TRIGGERED           = 50421,
+    SPELL_DK_SCOURGE_STRIKE_TRIGGERED           = 70890,
+    SPELL_DK_SHADOW_OF_DEATH                    = 164047,
+    SPELL_DK_SOUL_REAPER_DAMAGE                 = 114867,
+    SPELL_DK_SOUL_REAPER_HASTE                  = 114868,
+    SPELL_DK_T15_DPS_4P_BONUS                   = 138347,
+    SPELL_DK_UNHOLY_PRESENCE                    = 48265,
+    SPELL_DK_WILL_OF_THE_NECROPOLIS             = 206967,
+    SPELL_DK_BLOOD_BOIL_TRIGGERED               = 65658,
+    SPELL_DK_BLOOD_GORGED_HEAL                  = 50454,
+    SPELL_DK_DEATH_STRIKE_ENABLER               = 89832,
+    SPELL_DK_FROST_PRESENCE                     = 48266,
+    SPELL_DK_IMPROVED_FROST_PRESENCE            = 50385,
+    SPELL_DK_IMPROVED_FROST_PRESENCE_TRIGGERED  = 50385,
+    SPELL_DK_IMPROVED_UNHOLY_PRESENCE           = 50392,
+    SPELL_DK_IMPROVED_UNHOLY_PRESENCE_TRIGGERED = 55222,
+    SPELL_DK_RUNE_TAP                           = 48982,
+    SPELL_DK_CORPSE_EXPLOSION_VISUAL            = 51270,
+    SPELL_DK_MASTER_OF_GHOULS                   = 52143,
+    SPELL_DK_GHOUL_AS_GUARDIAN                  = 46585,
+    SPELL_DK_GHOUL_AS_PET                       = 52150,
+    SPELL_DK_ROILING_BLOOD                      = 108170,
+    SPELL_DK_PESTILENCE                         = 50842,
+    SPELL_DK_CHILBLAINS                         = 50041,
+    SPELL_DK_CHAINS_OF_ICE_ROOT                 = 53534,
+    SPELL_DK_PLAGUE_LEECH                       = 123693,
+    SPELL_DK_PERDITION                          = 123981,
+    SPELL_DK_SHROUD_OF_PURGATORY                = 116888,
+    SPELL_DK_PURGATORY_INSTAKILL                = 123982,
+    SPELL_DK_BLOOD_RITES                        = 50034,
+    SPELL_DK_DEATH_SIPHON_HEAL                  = 116783,
+    SPELL_DK_BLOOD_CHARGE                       = 114851,
+    SPELL_DK_BOOD_TAP                           = 45529,
+    SPELL_DK_PILLAR_OF_FROST                    = 51271,
+    SPELL_DK_CONVERSION                         = 119975,
+    SPELL_DK_WEAKENED_BLOWS                     = 115798,
+    SPELL_DK_SCARLET_FEVER                      = 81132,
+    SPELL_DK_SCENT_OF_BLOOD_AURA                = 50421,
+    SPELL_DK_DESECRATED_GROUND                  = 118009,
+    SPELL_DK_DESECRATED_GROUND_IMMUNE           = 115018,
+    SPELL_DK_ASPHYXIATE                         = 108194,
+    SPELL_DK_DARK_INFUSION_STACKS               = 91342,
+    SPELL_DK_DARK_INFUSION_AURA                 = 93426,
+    SPELL_DK_RUNIC_CORRUPTION_REGEN             = 51460,
+    SPELL_DK_RUNIC_EMPOWERMENT                  = 81229,
+    SPELL_DK_GOREFIENDS_GRASP_GRIP_VISUAL       = 114869,
+    SPELL_DK_SLUDGE_BELCHER_AURA                = 207313,
+    SPELL_DK_SLUDGE_BELCHER_ABOMINATION         = 212027,
+    SPELL_DK_RAISE_DEAD                         = 46584,
+    SPELL_DK_RAISE_DEAD_GHOUL                   = 52150,
+    SPELL_DK_GEIST_TRANSFORM                    = 121916,
+    SPELL_DK_ANTI_MAGIC_BARRIER                 = 205725,
+    SPELL_DK_RUNIC_CORRUPTION                   = 51462,
+    SPELL_DK_NECROSIS                           = 207346,
+    SPELL_DK_NECROSIS_EFFECT                    = 216974,
+    SPELL_DK_ALL_WILL_SERVE                     = 194916,
+    SPELL_DK_ALL_WILL_SERVE_SUMMON              = 196910,
+    SPELL_DK_BREATH_OF_SINDRAGOSA               = 152279,
+    SPELL_DK_DEATH_GRIP_ONLY_JUMP               = 146599,
+    SPELL_DK_HEART_STRIKE                       = 206930,
+    SPELL_DK_FESTERING_WOUND                    = 194310,
+    SPELL_DK_FESTERING_WOUND_DAMAGE             = 194311,
+    SPELL_DK_BONE_SHIELD                        = 195181,
+    SPELL_DK_BLOOD_MIRROR_DAMAGE                = 221847,
+    SPELL_DK_BLOOD_MIRROR                       = 206977,
+    SPELL_DK_BONESTORM_HEAL                     = 196545,
+    SPELL_DK_GLACIAL_ADVANCE                    = 194913,
+    SPELL_DK_GLACIAL_ADVANCE_DAMAGE             = 195975,
+    SPELL_DK_HOWLING_BLAST                      = 49184,
+    SPELL_DK_HOWLING_BLAST_AOE                  = 237680,
+    SPELL_DK_RIME_BUFF                          = 59052,
+    SPELL_DK_NORTHREND_WINDS                    = 204088,
+    SPELL_DK_KILLING_MACHINE                    = 51124,
+    SPELL_DK_REMORSELESS_WINTER_SLOW_DOWN       = 211793,
+    SPELL_DK_EPIDEMIC                           = 207317,
+    SPELL_DK_EPIDEMIC_DAMAGE_SINGLE             = 212739,
+    SPELL_DK_EPIDEMIC_DAMAGE_AOE                = 215969,
+    SPELL_DK_VIRULENT_PLAGUE                    = 191587,
+    SPELL_DK_VIRULENT_ERUPTION                  = 191685,
+    SPELL_DK_OUTBREAK_PERIODIC                  = 196782,
+    SPELL_DK_DEFILE                             = 152280,
+    SPELL_DK_DEFILE_DAMAGE                      = 156000,
+    SPELL_DK_DEFILE_DUMMY                       = 156004,
+    SPELL_DK_DEFILE_MASTERY                     = 218100,
+    SPELL_DK_UNHOLY_FRENZY                      = 207289,
+    SPELL_DK_UNHOLY_FRENZY_BUFF                 = 207290,
+    SPELL_DK_PESTILENT_PUSTULES                 = 194917,
+    SPELL_DK_CASTIGATOR                         = 207305,
+    SPELL_DK_UNHOLY_VIGOR                       = 196263,
+
+    SPELL_DK_RECENTLY_USED_DEATH_STRIKE         = 180612,
+    SPELL_DK_FROST                              = 137006,
+    SPELL_DK_DEATH_STRIKE_OFFHAND               = 66188,
+};
+
 // Desecrated ground - 118009
 class spell_dk_desecrated_ground : public SpellScriptLoader
 {
@@ -573,28 +712,115 @@ class spell_dk_death_pact : public SpellScriptLoader
         }
 };
 
-// Death Grip - 49576
-class spell_dk_death_grip_dummy : public SpellScript
+// 49998 - Death Strike
+/// 6.x
+class spell_dk_death_strike : public SpellScriptLoader
 {
-    PrepareSpellScript(spell_dk_death_grip_dummy);
+    public:
+        spell_dk_death_strike() : SpellScriptLoader("spell_dk_death_strike") { }
 
-    void HandleDummy(SpellEffIndex /*effIndex*/)
-    {
-        if (Unit* caster = GetCaster())
+        class spell_dk_death_strike_SpellScript : public SpellScript
         {
-            if (Unit* target = GetHitUnit())
-            {
-                if (caster->HasAura(137008)) // DK blood
-                    caster->CastSpell(target, 51399, true);
+            PrepareSpellScript(spell_dk_death_strike_SpellScript);
 
-                target->CastSpell(caster, 49575, true);
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                return ValidateSpellInfo(
+                {
+                    SPELL_DK_DEATH_STRIKE_HEAL,
+                    SPELL_DK_BLOOD_SHIELD_MASTERY,
+                    SPELL_DK_BLOOD_SHIELD_ABSORB,
+                    SPELL_DK_RECENTLY_USED_DEATH_STRIKE,
+                    SPELL_DK_FROST,
+                    SPELL_DK_DEATH_STRIKE_OFFHAND
+                });
             }
+
+            void HandleHeal(SpellEffIndex /*effIndex*/)
+            {
+                Unit* caster = GetCaster();
+
+                // max of 20% of dmg taken in past 5 sec, or 10% of health
+                int32 ten = CalculatePct(caster->GetMaxHealth(), GetSpellInfo()->GetEffect(EFFECT_4)->CalcValue());
+                int32 dmg = caster->GetDamageTakenInPastSecs(5) * 0.2f;
+                int32 heal = std::max(ten, dmg);
+
+                caster->CastCustomSpell(SPELL_DK_DEATH_STRIKE_HEAL, SPELLVALUE_BASE_POINT0, heal, caster, true);
+
+                if (AuraEffect const* aurEff = caster->GetAuraEffect(SPELL_DK_BLOOD_SHIELD_MASTERY, EFFECT_0))
+                    caster->CastCustomSpell(SPELL_DK_BLOOD_SHIELD_ABSORB, SPELLVALUE_BASE_POINT0, CalculatePct(heal, aurEff->GetAmount()), caster);
+
+                if (caster->HasAura(SPELL_DK_FROST))
+                    caster->CastSpell(GetHitUnit(), SPELL_DK_DEATH_STRIKE_OFFHAND, true);
+            }
+
+            void TriggerRecentlyUsedDeathStrike()
+            {
+                GetCaster()->CastSpell(GetCaster(), SPELL_DK_RECENTLY_USED_DEATH_STRIKE, true);
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_dk_death_strike_SpellScript::HandleHeal, EFFECT_1, SPELL_EFFECT_WEAPON_PERCENT_DAMAGE);
+                AfterCast += SpellCastFn(spell_dk_death_strike_SpellScript::TriggerRecentlyUsedDeathStrike);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_dk_death_strike_SpellScript();
+        }
+};
+
+// 49576 - Death Grip
+class spell_dk_death_grip_initial : public SpellScript
+{
+    PrepareSpellScript(spell_dk_death_grip_initial);
+
+    bool Validate(SpellInfo const* /*spellinfo*/) override
+    {
+        return ValidateSpellInfo({  SPELL_DK_DEATH_GRIP,
+                                    SPELL_DK_DEATH_GRIP_PULL,
+                                    SPELL_DK_DEATH_GRIP_VISUAL,
+                                    SPELL_DK_DEATH_GRIP_TAUNT });
+    }
+
+    SpellCastResult CheckCast()
+    {
+        Unit* caster = GetCaster();
+
+        // Death Grip should not be castable while jumping/falling
+        if (caster->HasUnitState(UNIT_STATE_JUMPING) || caster->HasUnitMovementFlag(MOVEMENTFLAG_FALLING))
+            return SPELL_FAILED_MOVING;
+
+        // Patch 3.3.3 (2010-03-23): Minimum range has been changed to 8 yards in PvP.
+        Unit* target = GetExplTargetUnit();
+        if (target && target->IsPlayer())
+            if (caster->GetDistance(target) < 8.f)
+                return SPELL_FAILED_TOO_CLOSE;
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleOnCast()
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetExplTargetUnit();
+
+        if (!target->HasAuraType(SPELL_AURA_DEFLECT_SPELLS))
+        {
+            caster->CastSpell(target, SPELL_DK_DEATH_GRIP_VISUAL, true);
+            target->CastSpell(caster, SPELL_DK_DEATH_GRIP_PULL, true);
+
+            if (caster->IsPlayer() && caster->ToPlayer()->GetSpecializationId() == TALENT_SPEC_DEATHKNIGHT_BLOOD)
+                caster->CastSpell(target, SPELL_DK_DEATH_GRIP_TAUNT, true);
         }
     }
 
     void Register() override
     {
-        OnEffectLaunchTarget += SpellEffectFn(spell_dk_death_grip_dummy::HandleDummy, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+        OnCheckCast += SpellCheckCastFn(spell_dk_death_grip_initial::CheckCast);
+        OnCast += SpellCastFn(spell_dk_death_grip_initial::HandleOnCast);
     }
 };
 
@@ -1640,22 +1866,19 @@ class spell_dk_marrowrend : public SpellScriptLoader
         {
             PrepareSpellScript(spell_dk_marrowrend_SpellScript);
 
-            void HandleOnCast()
+            void HandleHit(SpellEffIndex effIndex)
             {
-                if (Unit* caster = GetCaster())
-                {
-                    if (Unit* owner = caster->GetAnyOwner())
-                        caster = owner;
+                Unit* caster = GetCaster();
+                if (!caster)
+                    return;
 
-                    int32 count = GetSpellInfo()->Effects[EFFECT_2]->BasePoints;
-                    for (int i = 0; i < count; i++)
-                        caster->CastSpell(caster, 195181, true);
-                }
+                for (int i = 0; i < GetSpellInfo()->Effects[EFFECT_2]->BasePoints; i++)
+                    caster->CastSpell(caster, SPELL_DK_BONE_SHIELD, true);
             }
 
             void Register() override
             {
-                OnCast += SpellCastFn(spell_dk_marrowrend_SpellScript::HandleOnCast);
+                OnEffectHit += SpellEffectFn(spell_dk_marrowrend_SpellScript::HandleHit, EFFECT_2, SPELL_EFFECT_DUMMY);
             }
         };
 
@@ -2026,6 +2249,92 @@ class spell_dk_army_transform : public SpellScriptLoader
         }
 };
 
+// 50842 - Blood Boil
+class spell_dk_blood_boil : public SpellScriptLoader
+{
+    public:
+        spell_dk_blood_boil() : SpellScriptLoader("spell_dk_blood_boil") { }
+
+        class spell_dk_blood_boil_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_dk_blood_boil_SpellScript);
+
+            bool Validate(SpellInfo const* /*spellInfo*/) override
+            {
+                return ValidateSpellInfo({ SPELL_DK_BLOOD_PLAGUE });
+            }
+
+            void HandleOnHit(SpellEffIndex /*effIndex*/)
+            {
+                Unit* caster = GetCaster();
+                Unit* target = GetHitUnit();
+
+                caster->CastSpell(target, SPELL_DK_BLOOD_PLAGUE, true);
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_dk_blood_boil_SpellScript::HandleOnHit, EFFECT_0, SPELL_EFFECT_SCHOOL_DAMAGE);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_dk_blood_boil_SpellScript();
+        }
+};
+
+// 43265 - Death and Decay
+/// 6.x
+class spell_dk_death_and_decay : public SpellScriptLoader
+{
+    public:
+        spell_dk_death_and_decay() : SpellScriptLoader("spell_dk_death_and_decay") { }
+
+        class spell_dk_death_and_decay_SpellScript : public SpellScript
+        {
+            PrepareSpellScript(spell_dk_death_and_decay_SpellScript);
+
+            void HandleDummy(SpellEffIndex /*effIndex*/)
+            {
+                if (GetCaster()->HasAura(SPELL_DK_GLYPH_OF_DEATH_AND_DECAY))
+                    if (WorldLocation const* pos = GetExplTargetDest())
+                        GetCaster()->CastSpell(pos->GetPositionX(), pos->GetPositionY(), pos->GetPositionZ(), SPELL_DK_DEATH_AND_DECAY_SLOW, true);
+            }
+
+            void Register() override
+            {
+                OnEffectHitTarget += SpellEffectFn(spell_dk_death_and_decay_SpellScript::HandleDummy, EFFECT_0, SPELL_EFFECT_DUMMY);
+            }
+        };
+
+        class spell_dk_death_and_decay_AuraScript : public AuraScript
+        {
+            PrepareAuraScript(spell_dk_death_and_decay_AuraScript);
+
+            void HandleDummyTick(AuraEffect const* aurEff)
+            {
+                if (Unit* caster = GetCaster())
+                    caster->CastCustomSpell(SPELL_DK_DEATH_AND_DECAY_DAMAGE, SPELLVALUE_BASE_POINT0, aurEff->GetAmount(), GetTarget(), true, NULL, aurEff);
+            }
+
+            void Register() override
+            {
+                OnEffectPeriodic += AuraEffectPeriodicFn(spell_dk_death_and_decay_AuraScript::HandleDummyTick, EFFECT_2, SPELL_AURA_PERIODIC_DUMMY);
+            }
+        };
+
+        SpellScript* GetSpellScript() const override
+        {
+            return new spell_dk_death_and_decay_SpellScript();
+        }
+
+        AuraScript* GetAuraScript() const override
+        {
+            return new spell_dk_death_and_decay_AuraScript();
+        }
+};
+
 // 42651, 205491 - Army of the Dead
 class spell_dk_army_of_the_dead : public SpellScript
 {
@@ -2267,7 +2576,7 @@ void AddSC_deathknight_spell_scripts()
     new spell_dk_ghoul_explode();
     new spell_dk_death_gate_teleport();
     new spell_dk_death_gate();
-    RegisterSpellScript(spell_dk_death_grip_dummy);
+    RegisterSpellScript(spell_dk_death_grip_initial);
     new spell_dk_death_pact();
     new spell_dk_gorefiends_grasp();
     new spell_dk_corpse_explosion();
@@ -2312,4 +2621,7 @@ void AddSC_deathknight_spell_scripts()
     RegisterAuraScript(spell_dk_consumption_proc);
     RegisterSpellScript(spell_dk_pandemic_pvp);
     RegisterSpellScript(spell_dk_claw_owner);
+    new spell_dk_death_strike();
+    new spell_dk_blood_boil();
+    new spell_dk_death_and_decay();
 }

--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -741,9 +741,14 @@ class spell_dk_death_strike : public SpellScriptLoader
                 Unit* caster = GetCaster();
 
                 // max of 20% of dmg taken in past 5 sec, or 10% of health
-                int32 ten = CalculatePct(caster->GetMaxHealth(), GetSpellInfo()->GetEffect(EFFECT_4)->CalcValue());
-                int32 dmg = caster->GetDamageTakenInPastSecs(5) * 0.2f;
-                int32 heal = std::max(ten, dmg);
+
+                float pctDamage = caster->CanPvPScalar() ? GetSpellInfo()->GetEffect(EFFECT_2)->CalcValue() / 2 : GetSpellInfo()->GetEffect(EFFECT_2)->CalcValue();
+                int32 lastTime = GetSpellInfo()->GetEffect(EFFECT_3)->CalcValue();
+                int32 pctHeal = GetSpellInfo()->GetEffect(EFFECT_4)->CalcValue();
+
+                int32 minHeal = CalculatePct(caster->GetMaxHealth(), pctHeal);
+                int32 dmg = CalculatePct(caster->GetDamageTakenInPastSecs(lastTime, true, true), pctDamage);
+                int32 heal = std::max(minHeal, dmg);
 
                 caster->CastCustomSpell(SPELL_DK_DEATH_STRIKE_HEAL, SPELLVALUE_BASE_POINT0, heal, caster, true);
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Moves some DK spells into spell scripts
  - https://www.wowhead.com/spell=49998/death-strike
  - https://www.wowhead.com/spell=50842/blood-boil
  - https://www.wowhead.com/spell=43265/death-and-decay
- Cleans up a couple other DK spell scripts

**Issues addressed:**

- Fixes regression with spell effect radius

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
