### PR TITLE
Core/AHBot: fix seller pricing on items with market data

### DIFF
--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -633,7 +633,7 @@ void AuctionBotSeller::SetPricesOfItem(ItemTemplate const* itemProto, SellerConf
     // prefer market data when available
     auto marketData = _marketData.find(itemProto->GetId());
     if (marketData != _marketData.end())
-        basePriceFloat = marketData->second;
+        basePriceFloat = marketData->second * stackCount;
 
     float range = basePriceFloat * 0.04f;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

AHBot seller was incorrectly ignoring stack size when pricing items with market data. This fixes so market price is multiplied by stack size.

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
