### PR TITLE
Core/Common: fix a bug in BigNumber::AsByteArray that was causing inc…

### DIFF
--- a/src/common/Cryptography/BigNumber.cpp
+++ b/src/common/Cryptography/BigNumber.cpp
@@ -206,11 +206,11 @@ std::unique_ptr<uint8[]> BigNumber::AsByteArray(int32 minSize, bool littleEndian
     if (length > numBytes)
         memset((void*)array, 0, length);
 
-    BN_bn2bin(_bn, (unsigned char *)array);
+    BN_bn2bin(_bn, array + (length-numBytes));
 
     // openssl's BN stores data internally in big endian format, reverse if little endian desired
     if (littleEndian)
-        std::reverse(array, array + numBytes);
+        std::reverse(array, array + length);
 
     std::unique_ptr<uint8[]> ret(array);
     return ret;


### PR DESCRIPTION
…orrect output in 1/256 cases with explicit minSize (iff MSB zero)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-
-
-

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
