### PR TITLE
Core/Misc: fix shutdown crash by unloading world state

### DIFF
--- a/src/server/game/WorldStates/WorldState.cpp
+++ b/src/server/game/WorldStates/WorldState.cpp
@@ -83,6 +83,11 @@ void WorldState::Reload()
     Value = StateTemplate->DefaultValue;
 }
 
+void WorldState::Unload()
+{
+    ClientGuids.clear();
+}
+
 void WorldState::AddClient(ObjectGuid const& guid)
 {
     if (guid.IsPlayer())

--- a/src/server/game/WorldStates/WorldState.h
+++ b/src/server/game/WorldStates/WorldState.h
@@ -80,6 +80,8 @@ struct WorldState
 
     void Reload();
 
+    void Unload();
+
     void AddClient(ObjectGuid const& guid);
     bool HasClient(ObjectGuid const& guid);
     void RemoveClient(ObjectGuid const& guid);

--- a/src/server/game/WorldStates/WorldStateMgr.cpp
+++ b/src/server/game/WorldStates/WorldStateMgr.cpp
@@ -24,10 +24,6 @@ WorldStateMgr::WorldStateMgr()
     m_nextSave = sWorld->getIntConfig(CONFIG_INTERVAL_SAVE);
 }
 
-WorldStateMgr::~WorldStateMgr()
-{
-}
-
 WorldStateMgr& WorldStateMgr::Instance()
 {
     static WorldStateMgr instance;
@@ -72,6 +68,13 @@ void WorldStateMgr::Initialize()
     AddTemplate(WorldStates::WS_PVP_ARENA_ENABLED, WorldStatesData::Types::World, 0, 1 << WorldStatesData::Flags::InitialState, sWorld->getBoolConfig(CONFIG_ARENA_SEASON_IN_PROGRESS));
     AddTemplate(WorldStates::WS_ARENA_SEASON_ID, WorldStatesData::Types::World, 0, 1 << WorldStatesData::Flags::InitialState, sWorld->getIntConfig(CONFIG_ARENA_SEASON_ID));
     AddTemplate(WorldStates::WS_RATED_BG_ENABLED, WorldStatesData::Types::World, 0, 1 << WorldStatesData::Flags::InitialState, sWorld->getBoolConfig(CONFIG_ARENA_SEASON_IN_PROGRESS));
+}
+
+void WorldStateMgr::Unload()
+{
+    for (auto state : _worldStateV)
+        if (state)
+            state->Unload();
 }
 
 WorldStateTemplate const* WorldStateMgr::FindTemplate(uint32 variableID)

--- a/src/server/game/WorldStates/WorldStateMgr.h
+++ b/src/server/game/WorldStates/WorldStateMgr.h
@@ -13,12 +13,14 @@ class WorldStateMgr
 {
 public:
     WorldStateMgr();
-    ~WorldStateMgr();
+    ~WorldStateMgr() = default;
 
     void Update(uint32 diff);
 
     static WorldStateMgr& Instance();
     void Initialize();
+
+    void Unload();
 
     void LoadTemplatesFromDB();
     void LoadTemplatesFromObjectTemplateDB();

--- a/src/server/worldserver/Main.cpp
+++ b/src/server/worldserver/Main.cpp
@@ -57,6 +57,7 @@
 #include "World.h"
 #include "WorldSocket.h"
 #include "WorldSocketMgr.h"
+#include "WorldStateMgr.h"
 #include "Banner.h"
 
 #ifdef WIN32
@@ -257,6 +258,8 @@ extern int main(int argc, char **argv)
         //sInstanceSaveMgr->Unload();
         sOutdoorPvPMgr->Die();                    // unload it before MapManager
         sMapMgr->UnloadAll();                     // unload all grids (including locked in memory)
+
+        sWorldStateMgr.Unload();
     });
 
     // Start the Remote Access port (acceptor) if enabled


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- This fixes the shutdown crash caused by cds hash set unloading in world state destructor after SSL was already unloaded.

**Issues addressed:**

Closes #49 

**Tests performed:**

- Log in with at least one character
- Log out
- `.server exit` in console
- worldserver exits cleanly


**Known issues and TODO list:**

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
