### PR TITLE
Core/Summon: fix summon properties 121 SUMMON_TYPE_TOTEM

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -8455,6 +8455,10 @@ void SpellMgr::LoadSpellCustomAttr()
         }
     }
 
+    // 34980 Mennu's Healing Ward
+    if (auto* properties = const_cast<SummonPropertiesEntry*>(sSummonPropertiesStore.LookupEntry(121)))
+        properties->Title = SUMMON_TYPE_TOTEM;
+
     TC_LOG_INFO("server.loading", ">> Loaded spell custom attributes in %u ms", GetMSTimeDiffToNow(oldMSTime));
 
     oldMSTime = getMSTime();


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- This fixes summon properties 121 to use SUMMON_TYPE_TOTEM so it doesn't chase and attack the player
- Used by https://www.wowhead.com/spell=34980/mennus-healing-ward

**Issues addressed:**

none

**Tests performed:**

tested in-game; TC has similar fix

**Known issues and TODO list:**

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
