### PR TITLE
Core/Spells: fix strangulate aura effect

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -30033,7 +30033,7 @@ void Player::SendInitialPacketsAfterAddToMap(bool login)
                 (*auraList->begin())->HandleEffect(this, AURA_EFFECT_HANDLE_SEND_FOR_CLIENT, true);
     }
 
-    if (HasAuraType(SPELL_AURA_MOD_STUN))
+    if (HasAuraType(SPELL_AURA_MOD_STUN) || HasAuraType(SPELL_AURA_STRANGULATE))
         SetRooted(true);
 
     WorldPackets::Movement::MoveSetCompoundState setCompoundState;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -10714,7 +10714,7 @@ bool Unit::HandleProcTriggerSpell(Unit* victim, DamageInfo* dmgInfoProc, AuraEff
                 return false;
 
             if (procSpell->HasAura(SPELL_AURA_MOD_CONFUSE) || procSpell->HasAura(SPELL_AURA_MOD_FEAR) || procSpell->HasAura(SPELL_AURA_MOD_FEAR_2) ||
-                procSpell->HasAura(SPELL_AURA_MOD_STUN) || procSpell->HasAura(SPELL_AURA_STRANGULATE) || procSpell->HasAura(SPELL_AURA_MOD_ROOTED) || 
+                procSpell->HasAura(SPELL_AURA_MOD_STUN) || procSpell->HasAura(SPELL_AURA_STRANGULATE) || procSpell->HasAura(SPELL_AURA_MOD_ROOTED) ||
                 procSpell->HasAura(SPELL_AURA_MOD_SILENCE) || procSpell->Categories.Mechanic == MECHANIC_POLYMORPH || procSpell->Categories.Mechanic == MECHANIC_GRIP ||
                 (procEx & PROC_EX_INTERRUPT) || (procEx & PROC_EX_DISPEL))
             {
@@ -22428,7 +22428,7 @@ void Unit::SetControlled(bool apply, UnitState state)
 void Unit::ApplyControlStatesIfNeeded()
 {
     // Unit States might have been already cleared but auras still present. I need to check with HasAuraType
-    if (HasUnitState(UNIT_STATE_STUNNED) || HasAuraType(SPELL_AURA_MOD_STUN)) // || HasAuraType(SPELL_AURA_MOD_STUN_DISABLE_GRAVITY))
+    if (HasUnitState(UNIT_STATE_STUNNED) || HasAuraType(SPELL_AURA_MOD_STUN) || HasAuraType(SPELL_AURA_STRANGULATE))
         SetStunned(true);
 
     if (HasUnitState(UNIT_STATE_ROOT) || HasAuraType(SPELL_AURA_MOD_ROOT)) // || HasAuraType(SPELL_AURA_MOD_ROOT_2) || HasAuraType(SPELL_AURA_MOD_ROOT_DISABLE_GRAVITY))

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -8827,25 +8827,18 @@ void AuraEffect::HandleAuraStrangulate(AuraApplication const* aurApp, uint8 mode
     if (!target)
         return;
 
-    switch (m_spellInfo->Id)
-    {
-        case 108194: //Asphyxiate
-        case 221562: //Asphyxiate
-            target->SetControlled(apply, UNIT_STATE_STUNNED);
-            target->UpdateHeight(apply ? 1.0f : 0.0f);
-            break;
-        case 121448: //Encased in Resin
-        case 208944: //Elisande: Time Stop
-        case 249241: //Felhounds: Molten Touch
-            target->SetControlled(apply, UNIT_STATE_STUNNED);
-            break;
-        case 258373: //Argus: Grasp of the Unmaker
-            target->SetControlled(apply, UNIT_STATE_STUNNED);
-            target->SetDisableGravity(apply);
-            break;
-        default:
-            break;
-    }
+    target->SetControlled(apply, UNIT_STATE_STUNNED);
+
+    // Do not remove DisableGravity if there are more than this auraEffect of that kind on the unit or if it's a creature with DisableGravity on its movement template.
+    if (!apply
+        && (target->HasAuraType(GetAuraType())
+            //|| target->HasAuraType(SPELL_AURA_MOD_ROOT_DISABLE_GRAVITY)
+            || (target->IsCreature() && target->ToCreature()->GetMovementTemplate().Flight == CreatureFlightMovementType::DisableGravity)))
+        return;
+
+    if (target->SetDisableGravity(apply))
+        if (!apply && !target->IsFlying())
+            target->GetMotionMaster()->MoveFall();
 }
 
 void AuraEffect::HandleOverrideActionbarSpells(AuraApplication const* aurApp, uint8 mode, bool apply) const

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -8197,6 +8197,7 @@ SpellCastResult Spell::CheckCasterAuras() const
                         switch (part->GetAuraType())
                         {
                             case SPELL_AURA_MOD_STUN:
+                            case SPELL_AURA_STRANGULATE:
                                 if (!usableInStun || !(auraInfo->GetAllEffectsMechanicMask() & (1<<MECHANIC_STUN)))
                                     return SPELL_FAILED_STUNNED;
                                 break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- DK Asphyxiate spell https://www.wowhead.com/spell=221562/asphyxiate causes creatures to evade
- This fixes the strangulate aura effect so that it properly toggles disable gravity
- Now creatures can be attacked during and after asphyxiate

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:**

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
