### PR TITLE
Core/Loot: fix regression in Player::AutoStoreLoot

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -32585,7 +32585,7 @@ bool Player::AutoStoreLoot(uint8 bag, uint8 slot, uint32 loot_id, LootStore cons
     for (uint32 i = 0; i < max_slot; ++i)
     {
         LootItem* lootItem = loot.LootItemInSlot(i, this);
-        if (!loot.AllowedForPlayer(this, lootItem->item.ItemID, lootItem->type, lootItem->needs_quest, lootItem))
+        if (!loot.AllowedForPlayer(this, lootItem->item.ItemID, lootItem->item.CurrencyID, lootItem->type, lootItem->needs_quest, lootItem))
             continue;
 
         if (lootItem->currency)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes regression when looting items like https://www.wowhead.com/item=24476/jaggal-clam
- Regression was caused by #145 

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:**

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
