### PR TITLE
Core/Spells: fix spell effect charge

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -6827,7 +6827,7 @@ void Spell::EffectCharge(SpellEffIndex effIndex)
         }
 
         // Spell is not using explicit target - no generated path
-        if (m_preGeneratedPath->GetPathType() == PATHFIND_BLANK)
+        if (!m_preGeneratedPath || m_preGeneratedPath->GetPathType() == PATHFIND_BLANK)
         {
             Position pos = unitTarget->GetFirstCollisionPosition(unitTarget->GetObjectSize(), unitTarget->GetRelativeAngle(m_caster));
             m_caster->GetMotionMaster()->MoveCharge(pos.m_positionX, pos.m_positionY, pos.m_positionZ, speed, EVENT_CHARGE, false, unitTarget, std::to_address(spellEffectExtraData));


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes charge effect without pre-generated path, specifically https://www.wowhead.com/wotlk/spell=54878/merge

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
