### PR TITLE
Core/Gathering: update gathering xp calculation

### DIFF
--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1620,7 +1620,7 @@ class Player : public Unit, public GridObject<Player>
 
         void GiveXP(uint32 xp, Unit* victim, float groupRate = 1.0f);
         void SetXP(uint32 xp);
-        void GiveGatheringXP();
+        void GiveGatheringXP(uint32 xpLevel);
         void GiveLevel(uint8 level);
 
         void InitStatsForLevel(bool reapplyMods = false);

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -3480,6 +3480,7 @@ void Spell::EffectOpenLock(SpellEffIndex effIndex)
 
     Player* player = m_caster->ToPlayer();
 
+    uint32 xpLevel = 0;
     uint32 lockId = 0;
     ObjectGuid guid;
 
@@ -3544,6 +3545,7 @@ void Spell::EffectOpenLock(SpellEffIndex effIndex)
             return;
 
         lockId = goInfo->GetLockId();
+        xpLevel = goInfo->GetXpLevel();
         guid = gameObjTarget->GetGUID();
 
         if (auto const& goTemplate = sObjectMgr->GetGameObjectTemplate(gameObjTarget->GetEntry()))
@@ -3595,7 +3597,7 @@ void Spell::EffectOpenLock(SpellEffIndex effIndex)
                     player->UpdateGatherSkill(skillId, pureSkillValue, reqSkillValue, 1, gameObjTarget);
                     gameObjTarget->AddToSkillupList(player->GetGUID());
                     if (skillId == SKILL_MINING || skillId == SKILL_HERBALISM || skillId == SKILL_ARCHAEOLOGY)
-                        player->GiveGatheringXP();
+                        player->GiveGatheringXP(xpLevel);
                 }
             }
             else if (itemTarget)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Previously, gathering XP was always reduced by 90%
- Now, it scales down based on player level compared to chest/gathering node "xp level"
  - Formula is based on https://wowwiki-archive.fandom.com/wiki/Formulas:Gather_XP#XP_modification_based_on_character_Level

> Character_level  = Item_Level + 2 : (94.8%)   (Character lower level than gather level)
Character_level  = Item_Level + 1 : (97.4%)
Character_level <= Item_Level + 0 : (100%)    (Character level close to gather level)
Character_level >= Item_Level - 5 : (100%)    
Character_level  = Item_Level - 6 :  (80%)    (Character level exceeds gather level)
Character_level  = Item_Level - 7 :  (60%)
Character_level  = Item_Level - 8 :  (40%)
Character_level  = Item_Level - 8 :  (40%)
Character_level <= Item_Level - 10 : (10%)

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
