### PR TITLE
Core/AI: start to limit creature template spells to map difficulty

### DIFF
--- a/sql/updates/world/2024_11_17_creature_template_spell_difficulty.sql
+++ b/sql/updates/world/2024_11_17_creature_template_spell_difficulty.sql
@@ -1,0 +1,5 @@
+--
+ALTER TABLE `creature_template_spell`
+    ADD COLUMN `Difficulties` VARCHAR(100) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci' AFTER `difficultyMask`,
+    DROP COLUMN `timerCast`;
+

--- a/sql/updates/world/2024_11_17_creature_template_spell_difficulty_data.sql
+++ b/sql/updates/world/2024_11_17_creature_template_spell_difficulty_data.sql
@@ -1,0 +1,10 @@
+--
+UPDATE `creature_template_spell` SET `Difficulties` = '';
+
+-- DIFFICULTY_NORMAL, DIFFICULTY_10_N
+UPDATE `creature_template_spell` SET `Difficulties` = '1,3' WHERE `difficultyMask` = 1;
+
+-- DIFFICULTY_HEROIC
+UPDATE `creature_template_spell` SET `Difficulties` = '2' WHERE `difficultyMask` = 2;
+
+UPDATE `creature_template_spell` SET `Difficulties` = '1,2,3' WHERE `difficultyMask` = 3;

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -63,6 +63,18 @@
 
 #define ZONE_UPDATE_INTERVAL (10*IN_MILLISECONDS)
 
+bool CreatureSpell::CanUseInDifficulty(Difficulty difficulty) const
+{
+    if (Difficulties.empty())
+        return true;
+
+    for (Difficulty diff : Difficulties)
+        if (diff == difficulty)
+            return true;
+
+    return false;
+}
+
 CreatureMovementData::CreatureMovementData() : Ground(CreatureGroundMovementType::Run), Flight(CreatureFlightMovementType::None), Swim(true), Rooted(false), Random(CreatureRandomMovementType::Walk), InteractionPauseTimer(sWorld->getIntConfig(CONFIG_CREATURE_STOP_FOR_PLAYER)) { }
 
 std::string CreatureMovementData::ToString() const

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -115,9 +115,10 @@ const uint32 CREATURE_NOPATH_EVADE_TIME = 5 * IN_MILLISECONDS;
 struct CreatureSpell
 {
     uint32 SpellID;
-    uint32 DifficultyMask;
-    uint32 TimerCast;
+    std::vector<Difficulty> Difficulties;
     CreatureTextEntry const* Text;
+
+    bool CanUseInDifficulty(Difficulty difficulty) const;
 };
 typedef std::unordered_map<uint32, CreatureSpell> CreatureSpellList;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Add `Difficulties` column to `creature_template_spell` to list out explicit difficulties where the spell is allowed
- Drop unused column `creature_template_spell.timerCast`
- Update `CombatAI` and `ReactorAI` to ignore spells with explicit difficulties that do not contain the current map difficulty
  - Empty `Difficulties` column will maintain current behavior of allowing spell in all difficulties

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] Need to convert other `difficultyMask` entries to `Difficulties` list

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
