### PR TITLE
Core/Player: fix loading action bar spells

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -22398,6 +22398,8 @@ bool Player::LoadFromDB(ObjectGuid guid, CharacterDatabaseQueryHolder const& hol
     _LoadTalents(holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOADTALENTS), holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_PVP_TALENTS));
     _LoadSpells(holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOADSPELLS));
 
+    LearnSpecializationSpells();
+
     _LoadGlyphs(holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOAD_GLYPHS));
     _LoadAuras(holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOADAURAS), holder.GetPreparedResult(PLAYER_LOGIN_QUERY_LOADAURAS_EFFECTS), time_diff);
     _LoadGlyphAuras();
@@ -29936,8 +29938,6 @@ void Player::SendInitialPacketsBeforeAddToMap(bool login)
         m_reputationMgr.SendInitialReputations();
 
         SendCurrencies();
-
-        LearnSpecializationSpells();
     }
 
     // Reset Vignitte data


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Specialization spells, like https://www.wowhead.com/spell=51886/cleanse-spirit need to be learned before action bars are loaded
- This fixes items disappearing from action bars on login

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
