### PR TITLE
Core/Misc: remove win32-specific logging

### DIFF
--- a/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
+++ b/src/server/game/Entities/AreaTrigger/AreaTrigger.cpp
@@ -143,9 +143,7 @@ void AreaTrigger::AddToWorld()
 
 void AreaTrigger::RemoveFromWorld()
 {
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::RemoveFromWorld Entry: %u CustomEntry: %u", GetRealEntry(), GetCustomEntry());
-#endif
 
     ///- Remove the AreaTrigger from the accessor and from all lists of objects in world
     if (IsInWorld())
@@ -226,9 +224,7 @@ bool AreaTrigger::CreateAreaTrigger(ObjectGuid::LowType guidlow, uint32 triggerE
     else
         return false;
 
-#ifdef WIN32
-    TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger (spell %u) coordinates (X: %f Y: %f) _actionInfo %u", info ? info->Id : 0, GetPositionX(), GetPositionY(), _actionInfo.size());
-#endif
+    TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger (spell %u) coordinates (X: %f Y: %f) _actionInfo %zu", info ? info->Id : 0, GetPositionX(), GetPositionY(), _actionInfo.size());
 
     Object::_Create(ObjectGuid::Create<HighGuid::AreaTrigger>(GetMapId(), atInfo.customEntry, guidlow));
     if (caster)
@@ -359,11 +355,9 @@ bool AreaTrigger::CreateAreaTrigger(ObjectGuid::LowType guidlow, uint32 triggerE
     if (!GetMap()->AddToMap(this))
         return false;
 
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::Create AreaTrigger caster %s spellID %u spell rage %f dist %f dest - X:%f,Y:%f,Z:%f _nextMoveTime %i duration %i",
         caster ? caster->GetGUID().ToString().c_str() : ObjectGuid::Empty.ToString().c_str(), info ? info->Id : 0, _radius, GetSpellInfo() ? GetSpellInfo()->GetMaxRange() : 0.0f, _spline.VerticesPoints.empty() ? 0.0f : _spline.VerticesPoints[0].x, _spline.VerticesPoints.empty() ? 0.0f : _spline.VerticesPoints[0].y, _spline.VerticesPoints.empty() ? 0.0f : _spline.VerticesPoints[0].z, _nextMoveTime, duration);
-    TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::Create isMoving %i _range %f _spline.VerticesPoints %i moveType %i", isMoving(), _range, _spline.VerticesPoints.size(), atInfo.moveType);
-#endif
+    TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::Create isMoving %i _range %f _spline.VerticesPoints %zu moveType %i", isMoving(), _range, _spline.VerticesPoints.size(), atInfo.moveType);
 
     if (atInfo.maxCount && info && caster)
     {
@@ -380,8 +374,8 @@ bool AreaTrigger::CreateAreaTrigger(ObjectGuid::LowType guidlow, uint32 triggerE
     }
     UpdateAffectedList(0, AT_ACTION_MOMENT_SPAWN);
 
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger end (spell %u) coordinates (X: %f Y: %f)", info ? info->Id : 0, GetPositionX(), GetPositionY());
+#ifdef TRINITY_DEBUG
     DebugVisualizePolygon();
 #endif
 
@@ -724,9 +718,7 @@ void AreaTrigger::AffectOwner(AreaTriggerActionMoment actionM)
 
 void AreaTrigger::ActionOnUpdate(uint32 /*p_time*/)
 {
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "ActionOnUpdate");
-#endif
 
     // Action for AOE spell with cast on dest
     for (auto & itr : _actionInfo)
@@ -810,10 +802,8 @@ void AreaTrigger::DoAction(Unit* unit, ActionInfo& action)
     if (!caster || !unit || !action.charges && action.action->maxCharges)
         return;
 
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::DoAction caster %s unit %s type %u spellID %u, moment %u, targetFlags %u",
         caster->GetGUID().ToString().c_str(), unit->GetGUID().ToString().c_str(), action.action->actionType, action.action->spellId, action.action->moment, action.action->targetFlags);
-#endif
 
     if (action.action->targetFlags & AT_TARGET_FLAG_FRIENDLY)
         if (!caster || !caster->IsFriendlyTo(unit) || unit->isTotem())
@@ -1321,10 +1311,8 @@ void AreaTrigger::DoActionLeave(ActionInfo& action)
     if (!caster || !action.charges && action.action->maxCharges)
         return;
 
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::DoActionLeave caster %s type %u spellID %u, moment %u, targetFlags %u",
         caster->GetGUID().ToString().c_str(), action.action->actionType, action.action->spellId, action.action->moment, action.action->targetFlags);
-#endif
 
     switch (action.action->actionType)
     {
@@ -1640,9 +1628,7 @@ void AreaTrigger::InitSplines()
     if (_CircleData)
         _CircleData->TimeToTarget = _spline.TimeToTarget;
 
-    #ifdef WIN32
-        TC_LOG_DEBUG("entities.areatrigger", "InitSplines TimeToTarget %i _liveTime %u RePatchSpeed %f Speed %f movespline %s", _spline.TimeToTarget, _liveTime, atInfo.RePatchSpeed, atInfo.Speed, movespline->ToString().c_str());
-    #endif
+    TC_LOG_DEBUG("entities.areatrigger", "InitSplines TimeToTarget %i _liveTime %u RePatchSpeed %f Speed %f movespline %s", _spline.TimeToTarget, _liveTime, atInfo.RePatchSpeed, atInfo.Speed, movespline->ToString().c_str());
 
     if (_reachedDestination)
     {
@@ -1722,8 +1708,8 @@ void AreaTrigger::UpdateSplinePosition(uint32 diff)
         ReCalculateSplinePosition();
     }
 
-#ifdef WIN32
     TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::UpdateSplinePosition %f %f %f %i  _reachedDestination %u", GetPositionX(), GetPositionY(), GetPositionZ(), _movementTime, _reachedDestination);
+#ifdef TRINITY_DEBUG
     DebugVisualizePosition();
 #endif
 }
@@ -1944,16 +1930,16 @@ bool AreaTrigger::UpdatePosition(ObjectGuid targetGuid)
             if (relocated)
             {
                 GetMap()->AreaTriggerRelocation(this, caster->GetPositionX(), caster->GetPositionY(), caster->GetPositionZ(), caster->GetOrientation());
-                #ifdef WIN32
+#ifdef TRINITY_DEBUG
                 DebugVisualizePolygon();
-                #endif
+#endif
             }
             else if (turn)
             {
                 SetOrientation(caster->GetOrientation());
-                #ifdef WIN32
+#ifdef TRINITY_DEBUG
                 DebugVisualizePolygon();
-                #endif
+#endif
             }
         }
         else
@@ -2184,9 +2170,7 @@ void AreaTrigger::GetCollisionPosition(Position &_dest, float dist, float angle)
     Position pos;
     pos.Relocate(GetPositionX(), GetPositionY(), GetPositionZ() + 2.0f);
 
-#ifdef WIN32
-    TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates (X: %f Y: %f) ", pos.m_positionX, pos.m_positionY, pos.m_positionZ);
-#endif
+    TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates (X: %f Y: %f Z: %f) ", pos.m_positionX, pos.m_positionY, pos.m_positionZ);
 
     float destx = pos.m_positionX + dist * std::cos(angle);
     float desty = pos.m_positionY + dist * std::sin(angle);
@@ -2195,9 +2179,7 @@ void AreaTrigger::GetCollisionPosition(Position &_dest, float dist, float angle)
     bool col = VMAP::VMapFactory::createOrGetVMapManager()->getObjectHitPos(GetMapId(), pos.m_positionX, pos.m_positionY, pos.m_positionZ + 0.5f, destx, desty, destz + 0.5f, destx, desty, destz, -0.5f);
     if (!col)
     {
-    #ifdef WIN32
-        TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates !col  dest (X: %f Y: %f) ", destx, desty, destz);
-    #endif
+        TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates !col  dest (X: %f Y: %f Z: %f) ", destx, desty, destz);
 
         dist += 200.0f;
         destx = pos.m_positionX + dist * std::cos(angle);
@@ -2205,9 +2187,7 @@ void AreaTrigger::GetCollisionPosition(Position &_dest, float dist, float angle)
         VMAP::VMapFactory::createOrGetVMapManager()->getObjectHitPos(GetMapId(), pos.m_positionX, pos.m_positionY, pos.m_positionZ + 0.5f, destx, desty, destz + 0.5f, destx, desty, destz, -0.5f);
     }
 
-#ifdef WIN32
-    TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates  dest (X: %f Y: %f) Z %f", destx, desty, destz, GetPositionZ());
-#endif
+    TC_LOG_DEBUG("entities.areatrigger", "GetCollisionPosition coordinates  dest (X: %f Y: %f Z: %f) Z %f", destx, desty, destz, GetPositionZ());
 
     destx -= (CONTACT_DISTANCE + _radius) * std::cos(angle);
     desty -= (CONTACT_DISTANCE + _radius) * std::sin(angle);
@@ -2664,10 +2644,8 @@ void AreaTrigger::CalculateSplinePosition(Position const& pos, Position const& p
 
                 m_moveAngleLos = _dest.GetAngle(&_destAngle) - static_cast<float>(M_PI / 2);
 
-            #ifdef WIN32
                 TC_LOG_DEBUG("entities.areatrigger", "AT_MOVE_TYPE_RE_PATH_LOS _timeToTarget %i _dest (%f %f %f) %f",
                     _spline.TimeToTarget, _dest.GetPositionX(), _dest.GetPositionY(), _dest.GetPositionZ(), m_moveAngleLos);
-            #endif
             }
             break;
         }
@@ -2775,10 +2753,10 @@ void AreaTrigger::ReCalculateSplinePosition(bool setReach /*= false*/)
                 InitSplines();
             }
 
-            #ifdef WIN32
-            TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::UpdateMovement AT_MOVE_TYPE_RE_PATH size %i _timeToTarget %i dist %f", _spline.VerticesPoints.size(), _spline.TimeToTarget, dist);
-                DebugVisualizePosition();
-            #endif
+            TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::UpdateMovement AT_MOVE_TYPE_RE_PATH size %zu _timeToTarget %i dist %f", _spline.VerticesPoints.size(), _spline.TimeToTarget, dist);
+#ifdef TRINITY_DEBUG
+            DebugVisualizePosition();
+#endif
             break;
         }
         case AT_MOVE_TYPE_RE_PATH_LOS: //8
@@ -2804,7 +2782,9 @@ void AreaTrigger::ReCalculateSplinePosition(bool setReach /*= false*/)
 
             TC_LOG_DEBUG("entities.areatrigger", "AreaTrigger::UpdateMovement AT_MOVE_TYPE_RE_PATH_LOS size %zu _timeToTarget %i _dest (%f %f %f) %f",
                 _spline.VerticesPoints.size(), _spline.TimeToTarget, _dest.GetPositionX(), _dest.GetPositionY(), _dest.GetPositionZ(), m_moveAngleLos);
+#ifdef TRINITY_DEBUG
                 DebugVisualizePosition();
+#endif
             break;
         }
         default:

--- a/src/server/game/Entities/Creature/CreatureGroups.cpp
+++ b/src/server/game/Entities/Creature/CreatureGroups.cpp
@@ -199,10 +199,8 @@ void CreatureGroup::MemberAttackStart(Creature* member, Unit* target)
     if(!member || !target)
         return;
 
-    #ifdef WIN32
     if(m_leader)
-        TC_LOG_DEBUG("entities.unit", "CreatureGroup::MemberAttackStart: GetDBTableGUIDLow %u GetGUIDLow %u entry %u m_leader %u %u", member->GetDBTableGUIDLow(), member->GetGUIDLow(), member->GetEntry(), m_leader->GetEntry(), m_leader->GetGUIDLow());
-    #endif
+        TC_LOG_DEBUG("entities.unit", "CreatureGroup::MemberAttackStart: GetDBTableGUIDLow %lu GetGUIDLow %u entry %u m_leader %u %u", member->GetDBTableGUIDLow(), member->GetGUIDLow(), member->GetEntry(), m_leader->GetEntry(), m_leader->GetGUIDLow());
 
     uint8 groupAI = 0;
 

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -10519,9 +10519,7 @@ void Player::_ApplyItemBonuses(Item* item, uint8 slot, bool apply)
         if (val == 0)
             continue;
 
-        #ifdef WIN32
         TC_LOG_DEBUG("entities.player.items", "_ApplyItemBonuses statType %i val %i apply %u GetEntry %u", statType, val, apply, item->GetEntry());
-        #endif
 
         switch (statType)
         {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17917,9 +17917,7 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* target, uint32 procFlag, u
         }
     }
 
-    #ifdef WIN32
-    TC_LOG_DEBUG("spells", "ProcDamageAndSpell: procSpell %u procTriggered %u procFlag %u procExtra %u isVictim %u", procSpell ? procSpell->Id : 0, procTriggered.size(), procFlag, procExtra, isVictim);
-    #endif
+    TC_LOG_DEBUG("spells", "ProcDamageAndSpell: procSpell %u procTriggered %zu procFlag %u procExtra %u isVictim %u", procSpell ? procSpell->Id : 0, procTriggered.size(), procFlag, procExtra, isVictim);
 
     // Nothing found
     if (procTriggered.empty())
@@ -19351,12 +19349,10 @@ bool Unit::SpellProcTriggered(Unit* victim, DamageInfo* dmgInfoProc, AuraEffect*
             if (!itr->randList.empty())
                 spell_trigger = Trinity::Containers::SelectRandomContainerElement(itr->randList);
 
-            #ifdef WIN32
-            TC_LOG_DEBUG("spells", "SpellTriggered target %u, caster %u, spell_trigger %i, chance %i, triggerAmount %i, damage %i, GetAbsorb %i, GetResist %i, GetBlock %i",
+            TC_LOG_DEBUG("spells", "SpellTriggered target %u, caster %u, spell_trigger %i, chance %i, triggerAmount %f, damage %i, GetAbsorb %i, GetResist %i, GetBlock %i",
             itr->target, itr->caster, itr->spell_trigger, itr->chance, triggerAmount, damage, dmgInfoProc->GetAbsorb(), dmgInfoProc->GetResist(), dmgInfoProc->GetBlock());
             TC_LOG_DEBUG("spells", " group %i, effIndex %i, effectmask %i, option %i, (1<<effIndex) %i, procFlag %i addpowertype %i addptype %i procEx %i cooldown %f cooldown_spell_id %i",
             itr->group, effIndex, itr->effectmask, itr->option, (1<<effIndex), procFlag, addpowertype, itr->addptype, procEx, cooldown, cooldown_spell_id);
-            #endif
 
             if (G3D::fuzzyGt(cooldown, 0.0))
             {

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -424,9 +424,7 @@ void Map::LoadMapImpl(Map* map, int gx, int gy, bool reload)
     //map already load, delete it before reloading (Is it necessary? Do we really need the ability the reload maps during runtime?)
     if (map->GridMaps[gx][gy])
     {
-        #ifdef WIN32
-        TC_LOG_INFO("maps", "Unloading previously loaded map %u before reloading.", map->GetId());
-        #endif
+        TC_LOG_DEBUG("maps", "Unloading previously loaded map %u before reloading.", map->GetId());
         sScriptMgr->OnUnloadGridMap(map, map->GridMaps[gx][gy], gx, gy);
 
         delete (map->GridMaps[gx][gy]);
@@ -435,9 +433,7 @@ void Map::LoadMapImpl(Map* map, int gx, int gy, bool reload)
 
     // map file name
     std::string fileName = Trinity::StringFormat("%smaps/%04u_%02u_%02u.map", sWorld->GetDataPath().c_str(), map->GetId(), gx, gy);
-    #ifdef WIN32
-    TC_LOG_INFO("maps", "Loading map %s gx: %i, gy: %i", fileName.c_str(), gx, gy);
-    #endif
+    TC_LOG_DEBUG("maps", "Loading map %s gx: %i, gy: %i", fileName.c_str(), gx, gy);
     // loading data
     map->GridMaps[gx][gy] = new GridMap();
     GridMap::LoadResult gridMapLoadResult = map->GridMaps[gx][gy]->loadData(fileName.c_str());

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -259,10 +259,8 @@ void WorldSession::QueuePacket(WorldPacket* new_packet)
 /// Logging helper for unexpected opcodes
 void WorldSession::LogUnexpectedOpcode(WorldPacket* packet, const char* status, const char *reason)
 {
-    #ifdef WIN32
     TC_LOG_ERROR("network.opcode", "Received unexpected opcode %s Status: %s Reason: %s from %s",
         GetOpcodeNameForLogging(static_cast<OpcodeClient>(packet->GetOpcode())).c_str(), status, reason, GetPlayerName(false).c_str());
-    #endif
 }
 
 /// Logging helper for unexpected opcodes
@@ -271,11 +269,9 @@ void WorldSession::LogUnprocessedTail(WorldPacket const* packet)
     if (!sLog->ShouldLog("network", LOG_LEVEL_TRACE) || packet->rpos() >= packet->wpos())
         return;
 
-    #ifdef WIN32
     TC_LOG_ERROR("network.opcode", "Unprocessed tail data (read stop at %u from %u) Opcode %s from %s",
         uint32(packet->rpos()), uint32(packet->wpos()), GetOpcodeNameForLogging(static_cast<OpcodeClient>(packet->GetOpcode())).c_str(), GetPlayerName(false).c_str());
     packet->print_storage();
-    #endif
 }
 
 /// Update the WorldSession (triggered by World update)
@@ -344,9 +340,7 @@ bool WorldSession::Update(uint32 diff, Map* map)
                         {
                             requeuePackets.push_back(packet);
                             deletePacket = false;
-                            #ifdef WIN32
                             TC_LOG_ERROR("network", "Re-enqueueing packet with opcode %s with with status STATUS_LOGGEDIN. Player is currently not in world yet.", GetOpcodeNameForLogging(opcode).c_str());
-                            #endif
                         }
                     }
                     else if (_player->IsInWorld())
@@ -383,14 +377,10 @@ bool WorldSession::Update(uint32 diff, Map* map)
                     opHandle->Call(this, *packet);
                     break;
                 case STATUS_NEVER:
-                    #ifdef WIN32
                     TC_LOG_ERROR("network.opcode", "Received not allowed opcode %s from %s", GetOpcodeNameForLogging(opcode).c_str(), GetPlayerName(false).c_str());
-                    #endif
                     break;
                 case STATUS_UNHANDLED:
-                    #ifdef WIN32
                     TC_LOG_ERROR("network.opcode", "Received not handled opcode %s from %s", GetOpcodeNameForLogging(opcode).c_str(), GetPlayerName(false).c_str());
-                    #endif
                     break;
             }
         }

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -1362,9 +1362,7 @@ float AuraEffect::CalculateAmount(Unit* caster)
         if (target && target->IsPlayer() && (target->getRace() == RACE_PANDAREN_ALLIANCE || target->getRace() == RACE_PANDAREN_HORDE || target->getRace() == RACE_PANDAREN_NEUTRAL))
             amount *= 2;
 
-    #ifdef WIN32
-    TC_LOG_DEBUG("spells", "AuraApplication::CalculateAmount GetId %i GetAuraType %u amount %i effIndex %i m_amount_mod %f m_amount_add %i GetStackAmount %u", GetId(), GetAuraType(), amount, m_effIndex, m_amount_mod, m_amount_add, GetBase()->GetStackAmount());
-    #endif
+    TC_LOG_DEBUG("spells", "AuraApplication::CalculateAmount GetId %i GetAuraType %u amount %f effIndex %i m_amount_mod %f m_amount_add %f GetStackAmount %u", GetId(), GetAuraType(), amount, m_effIndex, m_amount_mod, m_amount_add, GetBase()->GetStackAmount());
 
     m_calc_amount = amount;
     return amount;

--- a/src/server/game/Spells/Auras/SpellAuras.cpp
+++ b/src/server/game/Spells/Auras/SpellAuras.cpp
@@ -129,10 +129,8 @@ void AuraApplication::_HandleEffect(uint8 effIndex, bool apply)
     if(HasEffect(effIndex) != (!apply))
         return;
     ASSERT((1<<effIndex) & _effectsToApply);
-    #ifdef WIN32
-    TC_LOG_DEBUG("spells", "AuraApplication::_HandleEffect: GetId %i, GetAuraType %u, apply: %u: amount: %i, m_send_baseAmount: %i, effIndex: %i GetDuration %i, guid %u GetStackAmount %u GetComboPoints %u GetCharges %u",
+    TC_LOG_DEBUG("spells", "AuraApplication::_HandleEffect: GetId %i, GetAuraType %u, apply: %u: amount: %f, m_send_baseAmount: %f, effIndex: %i GetDuration %i, guid %u GetStackAmount %u GetComboPoints %u GetCharges %u",
     GetBase()->GetId(), aurEff->GetAuraType(), apply, aurEff->GetAmount(), aurEff->GetBaseSendAmount(), effIndex, GetBase()->GetDuration(), GetBase()->GetOwner()->GetGUIDLow(), GetBase()->GetStackAmount(), GetBase()->GetComboPoints(), GetBase()->GetCharges());
-    #endif
 
     if (apply)
     {

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -737,14 +737,10 @@ void Spell::SelectImplicitNearbyTargets(SpellEffIndex effIndex, SpellImplicitTar
                     m_targets.SetDst(*referer);
                     return;
                 }
-#ifdef WIN32
                 TC_LOG_DEBUG("spells", "Spell::SelectImplicitNearbyTargets: no target destination on db: spell_target_position of spell ID %u, effect %u - selecting default targets", m_spellInfo->Id, effIndex);
-#endif
                 break;
             default:
-#ifdef WIN32
                 TC_LOG_DEBUG("spells", "Spell::SelectImplicitNearbyTargets: no conditions entry for target with TARGET_CHECK_ENTRY of spell ID %u, effect %u - selecting default targets", m_spellInfo->Id, effIndex);
-#endif
                 break;
         }
     }
@@ -752,15 +748,11 @@ void Spell::SelectImplicitNearbyTargets(SpellEffIndex effIndex, SpellImplicitTar
     WorldObject* target = SearchNearbyTarget(range, targetType.GetObjectType(), targetType.GetCheckType(), condList);
     if (!target)
     {
-        #ifdef WIN32
         TC_LOG_DEBUG("spells", "Spell::SelectImplicitNearbyTargets: cannot find nearby target for spell ID %u, effect %u", m_spellInfo->Id, effIndex);
-        #endif
         return;
     }
 
-    #ifdef WIN32
     TC_LOG_DEBUG("spells", "Spell::SelectImplicitNearbyTargets spell id %u caster %u target %u", m_spellInfo->Id, m_caster->GetGUIDLow(), target->GetGUIDLow());
-    #endif
 
     CallScriptObjectTargetSelectHandlers(target, effIndex);
 
@@ -3888,11 +3880,9 @@ SpellCastResult Spell::prepare(SpellCastTargets const* targets)
             SendChannelUpdate(0);
             m_triggeredByAura->GetBase()->SetDuration(0);
         }
-        #ifdef WIN32
         TC_LOG_DEBUG("spells", "Spell::prepare::CheckCast fail. spell id %u res %u m_caster %u m_originalCaster %u customCastFlags %u mask %u TargetGUID %u",
             m_spellInfo->Id, result, m_caster->GetGUIDLow(), m_originalCaster ? m_originalCaster->GetGUIDLow() : 0,
             _triggeredCastFlags, m_targets.GetTargetMask(), m_targets.GetObjectTargetGUID().GetGUIDLow());
-        #endif
         SendCastResult(result);
 
         finish(false);
@@ -3938,11 +3928,9 @@ SpellCastResult Spell::prepare(SpellCastTargets const* targets)
     // set timer base at cast time
     ReSetTimer();
 
-    #ifdef WIN32
     TC_LOG_DEBUG("spells", "Spell::prepare: spell id %u m_caster %u m_originalCaster %u customCastFlags %u mask %u target %s",
         m_spellInfo->Id, m_caster->GetGUIDLow(), m_originalCaster ? m_originalCaster->GetGUIDLow() : 0,
         _triggeredCastFlags, m_targets.GetTargetMask(), m_targets.GetUnitTarget() ? m_targets.GetUnitTarget()->ToString().c_str() : "" );
-    #endif
 
     LinkedSpell(m_caster, m_targets.GetUnitTarget(), SPELL_LINK_PREPARE_CAST);
 
@@ -4341,9 +4329,7 @@ void Spell::cast(bool skipCheck)
         SpellCastResult castResult = CheckCast(false);
         if (castResult != SPELL_CAST_OK)
         {
-            #ifdef WIN32
             TC_LOG_DEBUG("spells", "Spell::cast::checkcast fail. spell id %u res %u source %u caster %d customCastFlags %u mask %u", m_spellInfo->Id, castResult, m_caster->GetEntry(), m_originalCaster ? m_originalCaster->GetEntry() : -1, _triggeredCastFlags, m_targets.GetTargetMask());
-            #endif
             SendCastResult(castResult);
             SendInterrupted(0);
             //restore spell mods
@@ -5149,9 +5135,7 @@ void Spell::finish(bool ok)
             if (item->IsEquipable() && !item->IsEquipped())
                 m_caster->ToPlayer()->ApplyItemEquipSpell(item, false);
 
-    #ifdef WIN32
     TC_LOG_DEBUG("spells", "Spell::finish Spell: %u m_spellMissMask %u", m_spellInfo->Id, m_spellMissMask);
-    #endif
 
     LinkedSpell(m_caster, m_targets.GetUnitTarget(), SPELL_LINK_FINISH_CAST);
     CallScriptOnFinishCastHandlers();
@@ -6515,9 +6499,7 @@ void Spell::HandleEffects(Unit* pUnitTarget, Item* pItemTarget, GameObject* pGOT
             break;
     }
 
-    #ifdef WIN32
-    TC_LOG_DEBUG("spells", "Spell: %u Effect : %u, damage %i, mode %i idx %i preventDefault %u", m_spellInfo->Id, eff, damage, mode, i, preventDefault);
-    #endif
+    TC_LOG_DEBUG("spells", "Spell: %u Effect : %u, damage %f, mode %i idx %i preventDefault %u", m_spellInfo->Id, eff, damage, mode, i, preventDefault);
 
     if (!preventDefault && eff < TOTAL_SPELL_EFFECTS)
     {
@@ -10690,9 +10672,7 @@ bool WorldObjectSpellTargetCheck::operator()(WorldObject* target)
 
     if (res != SPELL_CAST_OK)
     {
-        #ifdef WIN32
         TC_LOG_DEBUG("spells", "Spell::WorldObjectSpellTargetCheck::checkcast fail. spell id %u res %u caster %s target %s", _spellInfo->Id, res, _caster->GetGUID().ToString().c_str(), target->GetGUID().ToString().c_str());
-        #endif
         return false;
     }
 
@@ -10705,11 +10685,6 @@ bool WorldObjectSpellTargetCheck::operator()(WorldObject* target)
         else
             return false;
     }
-
-    // #ifdef WIN32
-    // TC_LOG_DEBUG("spells", "Spell::WorldObjectSpellTargetCheck spell id %u caster %s target %s _condSrcInfo %u res %u ToCorpse %u ToUnit %u _targetSelectionType %u",
-    // _spellInfo->Id, _caster->GetGUID().ToString().c_str(), target->GetGUID().ToString().c_str(), bool(_condSrcInfo), res, bool(target->ToCorpse()), bool(target->ToUnit()), _targetSelectionType);
-    // #endif
 
     if (unitTarget)
     {

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -753,10 +753,8 @@ bool Spell::SpellDummyTriggered(SpellEffIndex effIndex)
 
         for (const auto& itr : *spellTrigger)
         {
-            #ifdef WIN32
             TC_LOG_DEBUG("spells", "Spell::EffectDummy %u, 1<<effIndex %u, itr->effectmask %u, option %u, spell_trigger %i, target %u (%u ==> %u) explTarget %u effectHandleMode %u",
             m_spellInfo->Id, 1 << effIndex, itr.effectmask, itr.option, itr.spell_trigger, itr.target, triggerTarget ? triggerTarget->GetGUIDLow() : 0, triggerCaster ? triggerCaster->GetGUIDLow() : 0, explTarget ? explTarget->GetGUIDLow() : 0, effectHandleMode);
-            #endif
 
             if (!(itr.handlemask & (1 << effectHandleMode)))
                 continue;
@@ -776,10 +774,8 @@ bool Spell::SpellDummyTriggered(SpellEffIndex effIndex)
                 targetAura = (m_originalCaster ? m_originalCaster : m_caster)->GetUnitForLinkedSpell(m_caster, unitTarget,
                                                                                                      itr.targetaura, explTarget);
 
-            #ifdef WIN32
             TC_LOG_DEBUG("spells", "Spell::EffectDummy2: %u, 1<<effIndex %u, itr->effectmask %u, option %u, spell_trigger %i, target %u (%u ==> %u)", m_spellInfo->Id, 1 << effIndex,
                            itr.effectmask, itr.option, itr.spell_trigger, itr.target, triggerTarget ? triggerTarget->GetGUIDLow() : 0, triggerCaster ? triggerCaster->GetGUIDLow() : 0);
-            #endif
 
             cooldown_spell_id = abs(itr.spell_trigger);
             if (triggerCaster)
@@ -1093,9 +1089,7 @@ bool Spell::SpellDummyTriggered(SpellEffIndex effIndex)
 
 void Spell::EffectDummy(SpellEffIndex effIndex)
 {
-    #ifdef WIN32
-    TC_LOG_DEBUG("spells", "EffectDummy end %i, m_diffMode %i, effIndex %i, spellId %u, damage %i, effectHandleMode %u, GetExplicitTargetMask %u", m_damage, m_diffMode, effIndex, m_spellInfo->Id, damage, effectHandleMode, m_spellInfo->GetExplicitTargetMask());
-    #endif
+    TC_LOG_DEBUG("spells", "EffectDummy end %i, m_diffMode %i, effIndex %i, spellId %u, damage %f, effectHandleMode %u, GetExplicitTargetMask %u", m_damage, m_diffMode, effIndex, m_spellInfo->Id, damage, effectHandleMode, m_spellInfo->GetExplicitTargetMask());
 
     uint32 spell_id = 0;
     int32 bp = 0;
@@ -4922,9 +4916,7 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
     int32 weaponDamage = _caster->CalculateDamage(m_attackType, normalized, m_spellInfo->GetSchoolMask() & SPELL_SCHOOL_MASK_NORMAL, unitTarget);
     bool calculateWPD = true;
 
-    #ifdef WIN32
     TC_LOG_DEBUG("spells", "Spell EffectWeaponDmg spellid %u in Effect(%u) fixed_bonus %i, weaponDamagePercentMod %f weaponDamage %i", m_spellInfo->Id, effIndex, fixed_bonus, weaponDamagePercentMod, weaponDamage);
-    #endif
 
     // Sequence is important
     for (int j = 0; j < MAX_SPELL_EFFECTS; ++j)
@@ -4962,9 +4954,7 @@ void Spell::EffectWeaponDmg(SpellEffIndex effIndex)
 
     m_damage += _damage;
 
-    #ifdef WIN32
     TC_LOG_DEBUG("spells", "Spell EffectWeaponDmg spellid %u in Effect(%u) weaponDamage %i, _damage %i m_damage %i effectHandleMode %i ComboPoints %i", m_spellInfo->Id, effIndex, weaponDamage, _damage, m_damage, effectHandleMode, GetComboPoints());
-    #endif
 
     switch (m_spellInfo->Id)
     {

--- a/src/server/scripts/Legion/TheNighthold/instance_the_nighthold.cpp
+++ b/src/server/scripts/Legion/TheNighthold/instance_the_nighthold.cpp
@@ -373,10 +373,6 @@ public:
 
         bool CheckRequiredBosses(uint32 bossId, uint32 /*entry*/, Player const* /*player*/ = nullptr) const override
         {
-            #ifdef WIN32
-                return true;
-            #endif
-
             switch (bossId)
             {
                 case DATA_ANOMALY:


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Removes some weird `#ifdef WIN32` blocks around logging
- Also switches `#ifdef WIN32` blocks around `DebugVisualizePolygon()` and `DebugVisualizePosition()` and replaces with `#ifdef TRINITY_DEBUG
- This fixes the issue where unexpected training dummies would spawn for all Windows servers :roll_eyes: 

**Issues addressed:**

none

**Tests performed:**

tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
