### PR TITLE
Core/Spells: fix mage mirror image display and ai

### DIFF
--- a/sql/updates/world/2024_11_21_fix_mage_mirror_image.sql
+++ b/sql/updates/world/2024_11_21_fix_mage_mirror_image.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 55342;
+
+DELETE FROM `spell_script_names` WHERE `spell_id` = 55342;
+INSERT INTO `spell_script_names` (spell_id, ScriptName) VALUES (55342, 'spell_mage_mirror_image_summon');

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -2084,6 +2084,10 @@ void AuraEffect::UpdatePeriodic(Unit* caster)
                             break;
                     }
                     break;
+                case SPELLFAMILY_MAGE:
+                    if (GetId() == 55342) // mirror image
+                        m_isPeriodic = false;
+                    break;
                 default:
                     break;
            }
@@ -7242,6 +7246,14 @@ void AuraEffect::HandlePeriodicDummyAuraTick(Unit* target, Unit* caster, SpellEf
                 if (GetTickNumber() > 1)
                     return;
             }
+            break;
+        }
+        case SPELLFAMILY_MAGE:
+        {
+            // Mirror Image
+            if (GetId() == 55342)
+                // Set name of summons to name of caster
+                caster->CastSpell((Unit*)nullptr, GetSpellEffectInfo()->TriggerSpell, true);
             break;
         }
         default:

--- a/src/server/scripts/Spells/spell_mage.cpp
+++ b/src/server/scripts/Spells/spell_mage.cpp
@@ -29,6 +29,175 @@
 //#include "AreaTriggerAI.h"
 //#include "AreaTrigger.h"
 
+enum MageSpells
+{
+    //7.3.2.25549
+    SPELL_MAGE_COLD_SNAP                         = 235219,
+    SPELL_MAGE_FROST_NOVA                        = 122,
+    SPELL_MAGE_CONE_OF_COLD                      = 120,
+    SPELL_MAGE_CONE_OF_COLD_SLOW                 = 212792,
+    SPELL_MAGE_ICE_BARRIER                       = 11426,
+    SPELL_MAGE_ICE_BLOCK                         = 45438,
+    SPELL_MAGE_GLACIAL_INSULATION                = 235297,
+    SPELL_MAGE_BONE_CHILLING                     = 205027,
+    SPELL_MAGE_BONE_CHILLING_BUFF                = 205766,
+    SPELL_MAGE_CHILLED                           = 205708,
+    SPELL_MAGE_ICE_LANCE                         = 30455,
+    SPELL_MAGE_ICE_LANCE_TRIGGER                 = 228598,
+    SPELL_MAGE_THERMAL_VOID                      = 155149,
+    SPELL_MAGE_ICY_VEINS                         = 12472,
+    SPELL_MAGE_GLACIAL_SPIKE                     = 199786,
+    SPELL_MAGE_ICICLE_PERIODIC_TRIGGER           = 148023,
+    SPELL_MAGE_FLURRY_DEBUFF_PROC                = 228354,
+    SPELL_MAGE_FLURRY                            = 44614,
+    SPELL_MAGE_FLURRY_DAMAGE                     = 228672,
+    SPELL_MAGE_FLURRY_CHILL_PROC                 = 228358,
+    SPELL_MAGE_FLURRY_VISUAL                     = 228596,
+    SPELL_MAGE_SHIELD_OF_ALODI                   = 195354,
+    SPELL_MAGE_BRAIN_FREEZE                      = 190447,
+    SPELL_MAGE_BRAIN_FREEZE_AURA                 = 190446,
+    SPELL_MAGE_BRAIN_FREEZE_IMPROVED             = 231584,
+    SPELL_MAGE_JOUSTER                           = 214626,
+    SPELL_MAGE_CHAIN_REACTION                    = 195419,
+    SPELL_MAGE_CHILLED_TO_THE_CORE               = 195448,
+    SPELL_MAGE_GLARITY_OF_THOUGHT                = 195351,
+    SPELL_MAGE_ICE_NOVA                          = 157997,
+    SPELL_MAGE_FROZEN_TOUCH                      = 205030,
+    SPELL_MAGE_FROZEN_ORB                        = 84714,
+    SPELL_MAGE_FROZEN_ORB_DAMAGE                 = 84721,
+    SPELL_MAGE_BLIZZARD_RANK_2                   = 236662,
+    SPELL_MAGE_UNSTABLE_MAGIC                    = 157976,
+    SPELL_MAGE_UNSTABLE_MAGIC_DAMAGE_FIRE        = 157977,
+    SPELL_MAGE_UNSTABLE_MAGIC_DAMAGE_FROST       = 157978,
+    SPELL_MAGE_UNSTABLE_MAGIC_DAMAGE_ARCANE      = 157979,
+    SPELL_MAGE_FINGERS_OF_FROST                  = 112965,
+    SPELL_MAGE_FINGERS_OF_FROST_AURA             = 44544,
+    SPELL_MAGE_FINGERS_OF_FROST_VISUAL_UI        = 126084,
+    SPELL_MAGE_FROST_BOMB_AURA                   = 112948,
+    SPELL_MAGE_FROST_BOMB_TRIGGERED              = 113092,
+    SPELL_MAGE_FROSTBOLT                         = 116,
+    SPELL_MAGE_FROSTBOLT_TRIGGER                 = 228597,
+    SPELL_MAGE_RAY_OF_FROST                      = 205021,
+    SPELL_MAGE_RAY_OF_FROST_BUFF                 = 208166,
+    SPELL_MAGE_RAY_OF_FROST_DAMAGE_INCREASE      = 208141,
+    SPELL_BLAZING_BARRIER_TRIGGER                = 235314,
+    SPELL_MAGE_SCORCH                            = 2948,
+    SPELL_MAGE_FIREBALL                          = 133,
+    SPELL_MAGE_FIRE_BLAST                        = 108853,
+    SPELL_MAGE_FLAMESTRIKE                       = 2120,
+    SPELL_MAGE_PYROBLAST                         = 11366,
+    SPELL_MAGE_PHOENIX_FLAMES                    = 194466,
+    SPELL_MAGE_DRAGON_BREATH                     = 31661,
+    SPELL_MAGE_PYROMANIAC                        = 205020,
+    SPELL_MAGE_ALEXSTRASZAS_FURY                 = 235870,
+    SPELL_MAGE_LIVING_BOMB_DAMAGE                = 44461,
+    SPELL_MAGE_LIVING_BOMB_DOT                   = 217694,
+    SPELL_MAGE_METEOR_DAMAGE                     = 153564,
+    SPELL_MAGE_METEOR_TIMER                      = 177345,
+    SPELL_MAGE_METEOR_VISUAL                     = 174556,
+    SPELL_MAGE_METEOR_BURN                       = 155158,
+    SPELL_MAGE_COMET_STORM                       = 153595,
+    SPELL_MAGE_COMET_STORM_DAMAGE                = 153596,
+    SPELL_MAGE_COMET_STORM_VISUAL                = 242210,
+    SPELL_MAGE_POLYMORPH_CRITTERMORPH            = 120091,
+    SPELL_MAGE_HEATING_UP                        = 48107,
+    SPELL_MAGE_HOT_STREAK                        = 48108,
+    SPELL_MAGE_ENHANCED_PYROTECHNICS_AURA        = 157644,
+
+    SPELL_MAGE_INCANTERS_FLOW_BUFF               = 116267,
+    SPELL_MAGE_RUNE_OF_POWER_BUFF                = 116014,
+    SPELL_MAGE_OVERPOWERED                       = 155147,
+    SPELL_MAGE_ARCANE_POWER                      = 12042,
+    SPELL_MAGE_CHRONO_SHIFT                      = 235711,
+    SPELL_MAGE_CHRONO_SHIFT_SLOW                 = 236299,
+    SPELL_MAGE_ARCANE_BLAST                      = 30451,
+    SPELL_MAGE_ARCANE_BARRAGE                    = 44425,
+    SPELL_MAGE_ARCANE_BARRAGE_TRIGGERED          = 241241,
+    SPELL_MAGE_PRESENCE_OF_MIND                  = 205025,
+    SPELL_MAGE_ARCANE_MISSILES_VISUAL_TWO        = 79808,
+    SPELL_MAGE_ARCANE_MISSILES_VISUAL_ONE        = 170571,
+    SPELL_MAGE_ARCANE_MISSILES_VISUAL_THREE      = 170572,
+    SPELL_MAGE_ARCANE_MISSILES_TRIGGER           = 7268,
+    SPELL_MAGE_ARCANE_MISSILES                   = 5143,
+    SPELL_MAGE_ARCANE_MISSILES_DAMAGE            = 7268,
+    SPELL_MAGE_ARCANE_MISSILES_POWER             = 208030,
+    SPELL_MAGE_ARCANE_MISSILES_CHARGES           = 79683,
+    SPELL_MAGE_ARCANE_ORB_DAMAGE                 = 153640,
+    SPELL_MAGE_ARCANE_AMPLIFICATION              = 236628,
+
+    //7.3.2.25549 END
+    SPELL_MAGE_RING_OF_FROST_FREEZE              = 82691,
+    SPELL_MAGE_RING_OF_FROST_IMMUNE              = 91264,
+    SPELL_MAGE_RING_OF_FROST                     = 113724,
+    SPELL_MAGE_FIRE_MAGE_PASSIVE                 = 137019,
+    SPELL_MAGE_FIRE_ON                           = 205029,
+    SPELL_MAGE_FIRESTARTER                       = 205026,
+    SPELL_MAGE_CAUTERIZE                         = 87023,
+    SPELL_MAGE_MIRROR_IMAGE_LEFT                 = 58834,
+    SPELL_MAGE_MIRROR_IMAGE_RIGHT                = 58833,
+    SPELL_MAGE_MIRROR_IMAGE_FRONT                = 58831,
+    SPELL_MAGE_COMBUSTION                        = 190319,
+    SPELL_MAGE_WATER_JET                         = 135029,
+    SPELL_MAGE_ICE_FLOES                         = 108839,
+    SPELL_MAGE_CONJURE_REFRESHMENT_GROUP         = 167145,
+    SPELL_MAGE_CONJURE_REFRESHMENT_SOLO          = 116136,
+    SPELL_MAGE_HYPOTHERMIA                       = 41425,
+    SPELL_INFERNO                                = 253220,
+    SPELL_MAGE_BLAZING_BARRIER                   = 235313,
+    SPELL_MAGE_BLAZING_SOUL                      = 235365,
+    SPELL_MAGE_CONTROLLED_BURN                   = 205033,
+    SPELL_MAGE_FLAME_PATCH                       = 205037,
+    SPELL_MAGE_FLAME_PATCH_TRIGGER               = 205470,
+    SPELL_MAGE_FLAME_PATCH_AOE_DMG               = 205472,
+    SPELL_MAGE_CINDERSTORM                       = 198929,
+    SPELL_MAGE_CINDERSTORM_DMG                   = 198928,
+    SPELL_MAGE_IGNITE_DOT                        = 12654,
+
+    SPELL_MAGE_SQUIRREL_FORM                     = 32813,
+    SPELL_MAGE_GIRAFFE_FORM                      = 32816,
+    SPELL_MAGE_SERPENT_FORM                      = 32817,
+    SPELL_MAGE_DRAGONHAWK_FORM                   = 32818,
+    SPELL_MAGE_WORGEN_FORM                       = 32819,
+    SPELL_MAGE_SHEEP_FORM                        = 32820,
+
+    SPELL_MAGE_MASTERY_ICICLES                   = 76613,
+    SPELL_MAGE_ICICLE_DAMAGE                     = 148022,
+    SPELL_MAGE_ICICLE_AURA                       = 205473,
+    SPELL_MAGE_SPLITTING_ICE                     = 56377
+};
+
+// Mirror Image - 55342
+class spell_mage_mirror_image_summon : public SpellScriptLoader
+{
+public:
+    spell_mage_mirror_image_summon() : SpellScriptLoader("spell_mage_mirror_image_summon") { }
+
+    class spell_mage_mirror_image_summon_SpellScript : public SpellScript
+    {
+        PrepareSpellScript(spell_mage_mirror_image_summon_SpellScript);
+
+        void HandleDummy(SpellEffIndex /*effIndex*/)
+        {
+            if (Unit* caster = GetCaster())
+            {
+                caster->CastSpell(caster, SPELL_MAGE_MIRROR_IMAGE_LEFT, true);
+                caster->CastSpell(caster, SPELL_MAGE_MIRROR_IMAGE_FRONT, true);
+                caster->CastSpell(caster, SPELL_MAGE_MIRROR_IMAGE_RIGHT, true);
+            }
+        }
+
+        void Register() override
+        {
+            OnEffectHitTarget += SpellEffectFn(spell_mage_mirror_image_summon_SpellScript::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
+        }
+    };
+
+    SpellScript* GetSpellScript() const override
+    {
+        return new spell_mage_mirror_image_summon_SpellScript();
+    }
+};
+
 // Cauterize - 86949
 class spell_mage_cauterize : public SpellScriptLoader
 {
@@ -441,21 +610,6 @@ const uint32 icicles[5][3]
     {148016, 148021, 148012}
 };
 
-enum MageSpells
-{
-    SPELL_MAGE_SQUIRREL_FORM                     = 32813,
-    SPELL_MAGE_GIRAFFE_FORM                      = 32816,
-    SPELL_MAGE_SERPENT_FORM                      = 32817,
-    SPELL_MAGE_DRAGONHAWK_FORM                   = 32818,
-    SPELL_MAGE_WORGEN_FORM                       = 32819,
-    SPELL_MAGE_SHEEP_FORM                        = 32820,
-
-    SplittingIce                                 = 56377,
-    IciclesStack                                 = 205473,
-    IciclesDamage                                = 148022,
-    MasteryIcicles                               = 76613
-};
-
 enum SilvermoonPolymorph
 {
     NPC_AUROSALIA   = 18744,
@@ -666,7 +820,7 @@ class spell_mage_icicle : public AuraScript
     {
         if (Unit* caster = GetCaster())
         {
-            if (Aura* aura = caster->GetAura(MasteryIcicles))
+            if (Aura* aura = caster->GetAura(SPELL_MAGE_MASTERY_ICICLES))
             {
                 for (auto itr : aura->m_loadedScripts)
                 {
@@ -683,7 +837,7 @@ class spell_mage_icicle : public AuraScript
                                     if (icicles[i][0] == spellId)
                                     {
                                         caster->CastSpell(target, icicles[i][1], true);
-                                        caster->CastCustomSpell(target, IciclesDamage, &tickamount, NULL, NULL, true);
+                                        caster->CastCustomSpell(target, SPELL_MAGE_ICICLE_DAMAGE, &tickamount, NULL, NULL, true);
                                         caster->RemoveAurasDueToSpell(spellId);
                                         return;
                                     }
@@ -1185,7 +1339,7 @@ class spell_mage_ice_lance_main : public SpellScript
         {
             Trinity::AnyDataContainer& cont = caster->GetAnyDataContainer();
 
-            if (caster->HasAura(MasteryIcicles) && !caster->HasSpell(199786)) // Mastery: Icicles, Glacial Spike
+            if (caster->HasAura(SPELL_MAGE_MASTERY_ICICLES) && !caster->HasSpell(199786)) // Mastery: Icicles, Glacial Spike
             {
                 if (Unit* target = GetOriginalTarget())
                 {
@@ -1205,7 +1359,7 @@ class spell_mage_ice_lance_main : public SpellScript
                 cont.Set("isFrozenTarget", 0);
             }
 
-            if (caster->HasAura(SplittingIce))
+            if (caster->HasAura(SPELL_MAGE_SPLITTING_ICE))
             {
                 if (Spell* spell = GetSpell())
                 {
@@ -1273,7 +1427,7 @@ class spell_mage_ice_lance : public SpellScript
                 {
                     if (target->GetGUID() == jumpTargetGUID)
                     {
-                        if (SpellInfo const* spellinfo = sSpellMgr->GetSpellInfo(SplittingIce))
+                        if (SpellInfo const* spellinfo = sSpellMgr->GetSpellInfo(SPELL_MAGE_SPLITTING_ICE))
                             dmgMod = CalculatePct(dmgMod, spellinfo->Effects[EFFECT_1]->BasePoints);
                     }
                 }
@@ -1734,7 +1888,7 @@ class spell_mage_mastery_icicles: public AuraScript
                                 if (AuraEffect const* eff = caster->GetAuraEffect(spellId, EFFECT_0))
                                 {
                                     float bp = eff->GetAmount();
-                                    caster->CastCustomSpell(target, IciclesDamage, &bp, NULL, NULL, true);
+                                    caster->CastCustomSpell(target, SPELL_MAGE_ICICLE_DAMAGE, &bp, NULL, NULL, true);
 
                                     for (uint8 i = 0; i < 5; i++)
                                     {
@@ -1770,7 +1924,7 @@ class spell_mage_mastery_icicles: public AuraScript
 
     void Cast(Unit* caster, uint32 const& spellId, float& damage)
     {
-        caster->CastSpell(caster, IciclesStack, true);
+        caster->CastSpell(caster, SPELL_MAGE_ICICLE_AURA, true);
         caster->CastCustomSpell(caster, spellId, &damage, NULL, NULL, true);
         getIcicles.push_back(spellId);
     }
@@ -2000,6 +2154,7 @@ public:
 
 void AddSC_mage_spell_scripts()
 {
+    new spell_mage_mirror_image_summon();
     new spell_mage_cauterize();
     new spell_mage_conjure_refreshment();
     new spell_mage_time_warp();

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -528,6 +528,29 @@ PersistentCharacterCleanFlags = 0
 ###################################################################################################
 
 ###################################################################################################
+# SERVER LOGGING
+#
+#    PidFile
+#        Description: World daemon PID file.
+#        Example:     "./world.pid" - (Enabled)
+#        Default:     ""            - (Disabled)
+
+PidFile = ""
+
+#
+#    PacketLogFile
+#        Description: Binary packet logging file for the world server.
+#                     Filename extension must be .pkt to be parsable with WowPacketParser.
+#        Example:     "World.pkt" - (Enabled)
+#        Default:     ""          - (Disabled)
+
+PacketLogFile = ""
+
+# Extended Logging system configuration moved to end of file (on purpose)
+#
+###################################################################################################
+
+###################################################################################################
 # SERVER SETTINGS
 #
 #    GameType


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Ported mirror image scripts from Ashamane
- Mirror image summons will now display properly
- Mirror image summons will now attack with spell based on player spec

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
