### PR TITLE
Core/Gossip: refactor gossip menu tables and separate gossip_option_mailbox

### DIFF
--- a/sql/updates/world/2024_11_25_refactor_gossip_menu.sql
+++ b/sql/updates/world/2024_11_25_refactor_gossip_menu.sql
@@ -1,0 +1,21 @@
+--
+ALTER TABLE `gossip_menu`
+    DROP COLUMN `FriendshipFactionID`,
+    CHANGE COLUMN `Entry` `MenuID` INT UNSIGNED NOT NULL;
+
+ALTER TABLE `gossip_menu_option`
+    CHANGE COLUMN `OptionIndex` `OptionID` SMALLINT UNSIGNED NOT NULL DEFAULT '0',
+    CHANGE COLUMN `OptionNPC` `OptionIcon` MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+    CHANGE COLUMN `OptionText` `OptionText` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    CHANGE COLUMN `OptionBroadcastTextID` `OptionBroadcastTextID` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `OptionText`,
+    CHANGE COLUMN `OptionNpcflag` `OptionNpcFlag` INT UNSIGNED NOT NULL DEFAULT '0',
+    DROP COLUMN `OptionNpcflag2`,
+    CHANGE COLUMN `BoxText` `BoxText` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    DROP COLUMN `BoxCurrency`;
+
+ALTER TABLE `gossip_menu_option_locale`
+    CHANGE COLUMN `ID` `OptionID` MEDIUMINT UNSIGNED NOT NULL DEFAULT '0',
+    CHANGE COLUMN `Locale` `Locale` VARCHAR(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+    CHANGE COLUMN `OptionText` `OptionText` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    CHANGE COLUMN `BoxText` `BoxText` TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+    DROP COLUMN `VerifiedBuild`;

--- a/sql/updates/world/2024_11_25_separate_gossip_option_mailbox.sql
+++ b/sql/updates/world/2024_11_25_separate_gossip_option_mailbox.sql
@@ -1,0 +1,2 @@
+--
+UPDATE `gossip_menu_option` SET `OptionType` = 29 WHERE `MenuID` IN (15948, 22084) AND `OptionID` = 0;

--- a/src/server/game/AI/ScriptedAI/ScriptedGossip.h
+++ b/src/server/game/AI/ScriptedAI/ScriptedGossip.h
@@ -70,21 +70,21 @@ enum eTradeskill
     GOSSIP_SENDER_SEC_STABLEMASTER      = 10
 };
 
-// Defined fuctions to use with player.
+// Defined functions to use with player.
 
-// This fuction add's a menu item,
+// This function adds a menu item,
 // a - Icon Id
 // b - Text
 // c - Sender(this is to identify the current Menu with this item)
-// d - Action (identifys this Menu Item)
+// d - Action (identifies this Menu Item)
 // e - Text to be displayed in pop up box
 // f - Money value in pop up box
 #define ADD_GOSSIP_ITEM(a, b, c, d)   PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, a, b, c, d, "", 0)
 #define ADD_GOSSIP_ITEM_DB(h, i, c, d)   PlayerTalkClass->GetGossipMenu().AddMenuItem(h, i, c, d)
-#define ADD_GOSSIP_ITEM_EXTENDED(a, b, c, d, e, f, g)   PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, a, b, c, d, e, f, 0, g)
+#define ADD_GOSSIP_ITEM_EXTENDED(a, b, c, d, e, f, g)   PlayerTalkClass->GetGossipMenu().AddMenuItem(-1, a, b, c, d, e, f, g)
 
-// This fuction Sends the current menu to show to client, a - NPCTEXTID(uint32), b - npc guid(uint64)
-#define SEND_GOSSIP_MENU(a, b)      PlayerTalkClass->SendGossipMenu(a, b, 0)
+// This function Sends the current menu to show to client, a - NPCTEXTID(uint32), b - npc guid(uint64)
+#define SEND_GOSSIP_MENU(a, b)      PlayerTalkClass->SendGossipMenu(a, b)
 
 // Closes the Menu
 #define CLOSE_GOSSIP_MENU()        PlayerTalkClass->SendCloseGossip()

--- a/src/server/game/Conditions/ConditionMgr.cpp
+++ b/src/server/game/Conditions/ConditionMgr.cpp
@@ -1508,7 +1508,7 @@ bool ConditionMgr::addToGossipMenus(Condition* cond)
     {
         for (auto itr = menuBounds.first; itr != menuBounds.second; ++itr)
         {
-            if ((*itr).second.Entry == cond->SourceGroup && (*itr).second.TextID == uint32(cond->SourceEntry))
+            if ((*itr).second.MenuID == cond->SourceGroup && (*itr).second.TextID == uint32(cond->SourceEntry))
             {
                 (*itr).second.Conditions.push_back(cond);
                 return true;

--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -39,7 +39,7 @@ GossipMenu::~GossipMenu()
     ClearMenu();
 }
 
-void GossipMenu::AddMenuItem(int32 menuItemId, uint8 icon, std::string const& message, uint32 sender, uint32 action, std::string const& boxMessage, uint32 boxMoney, uint32 boxCurrency, bool coded /*= false*/)
+void GossipMenu::AddMenuItem(int32 menuItemId, uint8 icon, std::string const& message, uint32 sender, uint32 action, std::string const& boxMessage, uint32 boxMoney, bool coded /*= false*/)
 {
     ASSERT(_menuItems.size() <= GOSSIP_MAX_MENU_ITEMS);
 
@@ -61,15 +61,13 @@ void GossipMenu::AddMenuItem(int32 menuItemId, uint8 icon, std::string const& me
 
     GossipMenuItem menuItem;
 
-    menuItem.OptionNPC = icon;
+    menuItem.MenuItemIcon = icon;
     menuItem.Message = message;
     menuItem.IsCoded = coded;
     menuItem.Sender = sender;
     menuItem.OptionType = action;
     menuItem.BoxMessage = boxMessage;
     menuItem.BoxMoney = boxMoney;
-    menuItem.BoxCurrency = boxCurrency;
-    menuItem.menuItemId = menuItemId;
 
     _menuItems[menuItemId] = menuItem;
 }
@@ -102,7 +100,7 @@ void GossipMenu::AddMenuItem(uint32 menuId, uint32 menuItemId, uint32 sender, ui
                 ObjectMgr::GetLocaleString(gossipMenuLocale->BoxText, GetLocale(), strBoxText);
         }
 
-        AddMenuItem(-1, itr->second.OptionNPC, strOptionText, sender, action, strBoxText, itr->second.BoxMoney, itr->second.BoxCurrency, itr->second.BoxCoded);
+        AddMenuItem(-1, itr->second.OptionIcon, strOptionText, sender, action, strBoxText, itr->second.BoxMoney, itr->second.BoxCoded);
     }
 }
 
@@ -219,21 +217,20 @@ bool PlayerMenu::IsGossipOptionCoded(uint32 selection) const
     return _gossipMenu.IsMenuItemCoded(selection);
 }
 
-void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID, uint32 friendshipFactionID /*= 0*/) const
+void PlayerMenu::SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID) const
 {
     WorldPackets::NPC::GossipMessage packet;
     packet.GossipGUID = objectGUID;
     packet.TextID = titleTextId;
     packet.GossipID = _gossipMenu.GetMenuId();
-    packet.FriendshipFactionID = friendshipFactionID;
 
     for (auto const& itr : _gossipMenu.GetMenuItems())
     {
         auto const& item = itr.second;
 
         WorldPackets::NPC::ClientGossipOptions opt;
-        opt.ClientOption = item.menuItemId;
-        opt.OptionNPC = item.OptionNPC;
+        opt.ClientOption = itr.first;
+        opt.OptionNPC = item.MenuItemIcon;
         opt.OptionFlags = item.IsCoded;
         opt.OptionCost = item.BoxMoney;
         opt.Text = item.Message;

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -47,8 +47,8 @@ enum Gossip_Option
     GOSSIP_OPTION_STABLEPET             = 14,                   //UNIT_NPC_FLAG_STABLE              (4194304)
     GOSSIP_OPTION_ARMORER               = 15,                   //UNIT_NPC_FLAG_ARMORER             (4096)
     GOSSIP_OPTION_UNLEARNTALENTS        = 16,                   //UNIT_NPC_FLAG_TRAINER             (16) (bonus option for GOSSIP_OPTION_TRAINER)
-    GOSSIP_OPTION_MAILBOX               = 18,                   //UNIT_NPC_FLAG_MAILBOX
     GOSSIP_OPTION_OUTDOORPVP            = 19,                   //added by code (option for outdoor pvp creatures)
+    GOSSIP_OPTION_LEARNDUALSPEC         = 18,                   //UNIT_NPC_FLAG_TRAINER             (16) (bonus option for GOSSIP_OPTION_TRAINER)
     GOSSIP_OPTION_TRANSMOGRIFIER        = 20,                   //UNIT_NPC_FLAG_TRANSMOGRIFIER
     GOSSIP_OPTION_SCENARIO              = 21,                   //UNIT_NPC_FLAG_GOSSIP
     GOSSIP_OPTION_GARRISON_SHIPMENT     = 22,                   //UNIT_NPC_FLAG2_AI_OBSTACLE 
@@ -58,6 +58,7 @@ enum Gossip_Option
     GOSSIP_OPTION_CHOICE                = 26,                   //UNIT_NPC_FLAG_GOSSIP
     GOSSIP_OPTION_ARTIFACT_RESPEC       = 27,                   //UNIT_NPC_FLAG_ARTIFACT_POWER_RESPEC
     GOSSIP_OPTION_ALLIED_RACE_DETAILS   = 28,                   // SMSG_OPEN_ALLIED_RACE_DETAILS
+    GOSSIP_OPTION_MAILBOX               = 29,                   //UNIT_NPC_FLAG_MAILBOX
     GOSSIP_OPTION_MAX
 };
 
@@ -140,14 +141,12 @@ enum Poi_Icon
 
 struct GossipMenuItem
 {
+    uint8 MenuItemIcon;
     uint32 Sender;
     uint32 OptionType;
     uint32 BoxMoney;
-    uint32 menuItemId;
-    uint32 BoxCurrency;
     std::string Message;
     std::string BoxMessage;
-    uint8 OptionNPC;
     bool IsCoded;
 };
 
@@ -181,7 +180,7 @@ public:
     GossipMenu();
     ~GossipMenu();
 
-    void AddMenuItem(int32 menuItemId, uint8 icon, std::string const& message, uint32 sender, uint32 action, std::string const& boxMessage, uint32 boxMoney, uint32 boxCurrency = 0, bool coded = false);
+    void AddMenuItem(int32 menuItemId, uint8 icon, std::string const& message, uint32 sender, uint32 action, std::string const& boxMessage, uint32 boxMoney, bool coded = false);
     void AddMenuItem(uint32 menuId, uint32 menuItemId, uint32 sender, uint32 action);
 
     void SetMenuId(uint32 menu_id);
@@ -239,7 +238,7 @@ public:
     uint32 GetGossipOptionAction(uint32 selection) const;
     bool IsGossipOptionCoded(uint32 selection) const;
 
-    void SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID, uint32 friendshipFactionID = 0) const;
+    void SendGossipMenu(uint32 titleTextId, ObjectGuid objectGUID) const;
     void SendCloseGossip() const;
     void SendPointOfInterest(uint32 poiId) const;
     void SendQuestGiverStatus(QuestGiverStatus questStatus, ObjectGuid npcGUID) const;

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17983,11 +17983,9 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId /*= 0*/, bool 
 
         if (Creature* creature = source->ToCreature())
         {
-            if (!(itr->second.OptionNpcflag & npcflags))
+            if (!(itr->second.OptionNpcFlag & npcflags))
                 continue;
 
-            if (itr->second.OptionNpcflag2 && !(itr->second.OptionNpcflag2 & npcflags2))
-                continue;
             switch (itr->second.OptionType)
             {
                 case GOSSIP_OPTION_ARMORER:
@@ -18007,6 +18005,9 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId /*= 0*/, bool 
                     }
                     break;
                 }
+                case GOSSIP_OPTION_LEARNDUALSPEC:
+                    canTalk = false;
+                    break;
                 case GOSSIP_OPTION_TRAINER:
                     if (!creature->isCanTrainingOf(this, false))
                         canTalk = false;
@@ -18112,7 +18113,7 @@ void Player::PrepareGossipMenu(WorldObject* source, uint32 menuId /*= 0*/, bool 
             else if (GossipMenuItemsLocale const* gossipMenuLocale = sGossipDataStore->GetGossipMenuItemsLocale(MAKE_PAIR32(menuId, itr->second.OptionIndex)))
                 ObjectMgr::GetLocaleString(gossipMenuLocale->BoxText, localeConstant, strBoxText);
 
-            menu->GetGossipMenu().AddMenuItem(itr->second.OptionIndex, itr->second.OptionNPC, strOptionText, 0, itr->second.OptionType, strBoxText, itr->second.BoxMoney, itr->second.BoxCurrency, itr->second.BoxCoded);
+            menu->GetGossipMenu().AddMenuItem(itr->second.OptionIndex, itr->second.OptionIcon, strOptionText, 0, itr->second.OptionType, strBoxText, itr->second.BoxMoney, itr->second.BoxCoded);
             menu->GetGossipMenu().AddGossipMenuItemData(itr->second.OptionIndex, itr->second.ActionMenuID, itr->second.ActionPoiID);
         }
     }
@@ -18150,11 +18151,7 @@ void Player::SendPreparedGossip(WorldObject* source)
     if (uint32 menuId = PlayerTalkClass->GetGossipMenu().GetMenuId())
         textId = GetGossipTextId(menuId, source);
 
-    uint32 friendshipFactionID = 0;
-    if (uint32 menuId = PlayerTalkClass->GetGossipMenu().GetMenuId())
-        friendshipFactionID = GetGossipFriendshipFactionID(menuId, source);
-    
-    PlayerTalkClass->SendGossipMenu(textId, source->GetGUID(), friendshipFactionID);
+    PlayerTalkClass->SendGossipMenu(textId, source->GetGUID());
 }
 
 void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 menuId)
@@ -18185,17 +18182,7 @@ void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 men
         return;
 
     int32 cost = int32(item->BoxMoney);
-    int32 currencyID = int32(item->BoxCurrency);
-    if (currencyID)
-    {
-        if (!HasCurrency(currencyID, cost))
-        {
-            SendBuyError(BUY_ERR_NOT_ENOUGHT_MONEY);
-            PlayerTalkClass->SendCloseGossip();
-            return;
-        }
-    }
-    else if (!HasEnoughMoney(int64(cost)))
+    if (!HasEnoughMoney(int64(cost)))
     {
         SendBuyError(BUY_ERR_NOT_ENOUGHT_MONEY);
         PlayerTalkClass->SendCloseGossip();
@@ -18259,6 +18246,8 @@ void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 men
             break;
         case GOSSIP_OPTION_TRAINER:
             GetSession()->SendTrainerList(guid);
+            break;
+        case GOSSIP_OPTION_LEARNDUALSPEC:
             break;
         case GOSSIP_OPTION_UNLEARNTALENTS:
             PlayerTalkClass->SendCloseGossip();
@@ -18358,10 +18347,7 @@ void Player::OnGossipSelect(WorldObject* source, uint32 gossipListId, uint32 men
             return;
     }
 
-    if (currencyID)
-        ModifyCurrency(currencyID, -cost);
-    else
-        ModifyMoney(-cost);
+    ModifyMoney(-cost);
 }
 
 uint32 Player::GetGossipTextId(WorldObject* source)
@@ -18399,20 +18385,6 @@ uint32 Player::GetDefaultGossipMenuForSource(WorldObject* source)
     }
 
     return 0;
-}
-
-uint32 Player::GetGossipFriendshipFactionID(uint32 menuId, WorldObject* source)
-{
-    uint32 friendshipFactionID = 0;
-    if (!menuId)
-        return friendshipFactionID;
-
-    auto menuBounds = sGossipDataStore->GetGossipMenusMapBounds(menuId);
-    for (auto itr = menuBounds.first; itr != menuBounds.second; ++itr)
-        if (sConditionMgr->IsObjectMeetToConditions(this, source, itr->second.Conditions))
-            friendshipFactionID = itr->second.FriendshipFactionID;
-
-    return friendshipFactionID;
 }
 
 /*********************************************************/

--- a/src/server/game/Entities/Player/Player.h
+++ b/src/server/game/Entities/Player/Player.h
@@ -1947,7 +1947,6 @@ class Player : public Unit, public GridObject<Player>
         uint32 GetGossipTextId(uint32 menuId, WorldObject* source);
         uint32 GetGossipTextId(WorldObject* source);
         static uint32 GetDefaultGossipMenuForSource(WorldObject* source);
-        uint32 GetGossipFriendshipFactionID(uint32 menuId, WorldObject* source);
 
         /*********************************************************/
         /***                    QUEST SYSTEM                   ***/

--- a/src/server/game/Globals/GossipData.h
+++ b/src/server/game/Globals/GossipData.h
@@ -10,24 +10,21 @@ struct GossipMenuItems
     uint32          OptionBroadcastTextID;
     uint32          BoxBroadcastTextID;
     uint32          OptionType;
-    uint32          OptionNpcflag;
-    uint32          OptionNpcflag2;
+    uint32          OptionNpcFlag;
     uint32          ActionMenuID;
     uint32          ActionPoiID;
     uint32          BoxMoney;
-    uint32          BoxCurrency;
     std::string     OptionText;
     std::string     BoxText;
-    uint8           OptionNPC;
+    uint8           OptionIcon;
     bool            BoxCoded;
 };
 
 struct GossipMenus
 {
     ConditionList   Conditions;
-    uint32          Entry;
+    uint32          MenuID;
     uint32          TextID;
-    uint32          FriendshipFactionID;
 };
 
 typedef std::multimap<uint32, GossipMenus> GossipMenusContainer;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Refactor `gossip_menu`, `gossip_menu_option`, `gossip_menu_option_locale` tables to be *closer* to AzerothCore (for Keira3 support - see #166 
- Move `GOSSIP_OPTION_MAILBOX` from 18 (`GOSSIP_OPTION_LEARNDUALSPEC`) to 29 (unused) and migrate data
- Disable gossip menu options with type `GOSSIP_OPTION_LEARNDUALSPEC` to help with #178  

**Issues addressed:**

Helps with #178

**Tests performed:**

tested in-game

**Known issues and TODO list:**

- [ ] Keira3 still doesn't load `npc_text` because `textX_Y...` columns aren't present anymore; `broadcast_text` is used exclusively

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
