### PR TITLE
DB/Loot: fix loot for gameobject 176793

### DIFF
--- a/sql/updates/world/2024_11_25_fix_go_176793_loot.sql
+++ b/sql/updates/world/2024_11_25_fix_go_176793_loot.sql
@@ -2,4 +2,4 @@
 UPDATE `gameobject_template` SET `Data1` = 176793 WHERE `entry` = 176793;
 
 DELETE FROM `gameobject_loot_template` WHERE `Entry` = 176793;
-INSERT INTO gameobject_loot_template (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (176793, 13872, 0, 100, 1, 1, 0, 1, 1, '');
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (176793, 13872, 0, 100, 1, 1, 0, 1, 1, '');

--- a/sql/updates/world/2024_11_25_fix_go_176793_loot.sql
+++ b/sql/updates/world/2024_11_25_fix_go_176793_loot.sql
@@ -1,0 +1,5 @@
+--
+UPDATE `gameobject_template` SET `Data1` = 176793 WHERE `entry` = 176793;
+
+DELETE FROM `gameobject_loot_template` WHERE `Entry` = 176793;
+INSERT INTO gameobject_loot_template (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES (176793, 13872, 0, 100, 1, 1, 0, 1, 1, '');


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes loot id for game object 176793 https://www.wowhead.com/object=176793/bundle-of-wood
- Adds `gameobject_loot_template` record for https://www.wowhead.com/item=13872/bundle-of-wood

**Issues addressed:**

Closes #179

**Tests performed:**

tested in-game

**Known issues and TODO list:**

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
