### PR TITLE
Core/Movement: FollowMovementGenerator NULL target check

### DIFF
--- a/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/TargetedMovementGenerator.cpp
@@ -472,6 +472,9 @@ bool FollowMovementGenerator<Player>::DoUpdate(Player& owner, uint32 diff) { ret
 template<>
 bool FollowMovementGenerator<Creature>::DoUpdate(Creature& owner, uint32 diff)
 {
+    if (!GetTarget())
+        return false;
+
     if (!GetTarget()->IsInWorld() || !owner.IsInMap(GetTarget()))
         return false;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

* FollowMovementGenerator `NULL` target check

**Issues addressed:**

I encountered this crash while doing the Quest: Feeding the Hungry and the Hopeless ( 26271 ) [12]   https://www.wowhead.com/quest=26271
NPC: Homeless Stormwind Citizen ( 42384 ) [10] https://www.wowhead.com/npc=42384 may attempt to follow a `NULL` target, likely when heading to the `Westfall Stew` quest object.

![devenv_f00T0kJOjM](https://github.com/user-attachments/assets/641e60c0-2682-4dbf-8563-415a6e08e896)

![devenv_lKDzza5RAF](https://github.com/user-attachments/assets/3e47db4c-d6f8-4545-8f77-e8181703a667)

**Tests performed:**

in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
