### PR TITLE
Core/Scripts: Quest 26257 It's Alive! - Part 1

### DIFF
--- a/sql/updates/world/2024_11_29_quest_26257.sql
+++ b/sql/updates/world/2024_11_29_quest_26257.sql
@@ -1,0 +1,35 @@
+-- Creature Overloaded Harvest Golem 42381 SAI
+SET @ENTRY := 42381;
+UPDATE `creature_template` SET `AIName`='SmartAI', `unit_flags2` = 2049 WHERE `entry`= @ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(@ENTRY, 0, 0, 0, 1, 0, 100, 0, 3000, 6000, 3500, 6000, 11, 79084, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'When out of combat and timer at the begining between 3000 and 6000 ms (and later repeats every 3500 and 6000 ms) - Self: Cast spell Unbound Energy (79084) on Self // ');
+
+DELETE FROM `conditions` WHERE `SourceEntry`= 79084 AND `SourceTypeOrReferenceId`= 13;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ScriptName`, `Comment`) VALUES
+(13, 1, 79084, 0, 0, 31, 0, 3, 42381, 0, 0, '', 'Unbound Energy - Target Overloaded Harvest Golem');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName`= 'spell_westfall_unbound_energy';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(79084, 'spell_westfall_unbound_energy');
+
+-- Creature Overloaded Harvest Golem Vehicle 42601
+SET @ENTRY := 42601;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=@ENTRY;
+
+UPDATE `creature_template` SET `VehicleId`= 907, `spell1`= 79425, `spell2`= 79430, `ScriptName`= 'npc_westfall_overloaded_harvest_golem', `AIName` = '' WHERE `entry`= @ENTRY;
+
+DELETE FROM `conditions` WHERE `SourceEntry` = 79436 AND `SourceTypeOrReferenceId` IN (13, 17);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ScriptName`, `Comment`) VALUES
+(13, 2, 79436, 0, 0, 31, 0, 3, 42381, 0, 0, '', 'Wake Harvest Golem - Target Overloaded Harvest Golem');
+
+DELETE FROM `spell_script_names` WHERE `ScriptName` IN
+('spell_westfall_reaping_blows',
+'spell_westfall_wake_harvest_golem');
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(79425, 'spell_westfall_reaping_blows'),
+(79436, 'spell_westfall_wake_harvest_golem');
+
+DELETE FROM `creature_text` WHERE `CreatureID`= 42601;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `Comment`) VALUES
+(42601, 0, 0, 'You may only ride the Overloaded Harvest Golem at the Molsen Farm.', 42, 0, 100, 0, 0, 0, 42475, '');

--- a/sql/updates/world/2024_11_29_quest_26257.sql
+++ b/sql/updates/world/2024_11_29_quest_26257.sql
@@ -33,3 +33,18 @@ INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
 DELETE FROM `creature_text` WHERE `CreatureID`= 42601;
 INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `Comment`) VALUES
 (42601, 0, 0, 'You may only ride the Overloaded Harvest Golem at the Molsen Farm.', 42, 0, 100, 0, 0, 0, 42475, '');
+
+-- Creature Energized Harvest Reaper 42342
+SET @ENTRY := 42342;
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = @ENTRY;
+
+UPDATE `creature` SET `spawndist` = 8, `MovementType` = 1 WHERE `id` = @ENTRY;
+
+DELETE FROM `creature_template_spell` WHERE `entry` = @ENTRY;
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` = @ENTRY;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(@ENTRY, 0, 0, 0, 0, 0, 100, 0, 5000, 8000, 15000, 20000,  11, 7342, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 'Energized Harvest Reaper - In Combat - Cast \'Wide Slash\''),
+(@ENTRY, 0, 1, 0, 2, 0, 100, 0, 0, 40, 25000, 29000,  11, 80572, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Energized Harvest Reaper - Between 0-40% Health - Cast \'Energize!\'');

--- a/src/common/Utilities/Timer.h
+++ b/src/common/Utilities/Timer.h
@@ -150,7 +150,7 @@ private:
 
 struct TimeTrackerSmall
 {
-    explicit TimeTrackerSmall(uint32 expiry = 0) : i_expiryTime(expiry)
+    explicit TimeTrackerSmall(int32 expiry = 0) : i_expiryTime(expiry)
     {
     }
 
@@ -164,7 +164,7 @@ struct TimeTrackerSmall
         return i_expiryTime <= 0;
     }
 
-    void Reset(uint32 interval)
+    void Reset(int32 interval)
     {
         i_expiryTime = interval;
     }

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -378,7 +378,7 @@ void CreatureAI::MoveInLineOfSight(Unit* who)
     if (me->GetCreatureType() == CREATURE_TYPE_NON_COMBAT_PET) // non-combat pets should just stand there and look good;)
         return;
 
-    if (me->canStartAttack(who, false))
+    if (me->HasReactState(REACT_AGGRESSIVE) && me->canStartAttack(who, false))
         AttackStart(who);
 }
 

--- a/src/server/game/AI/CreatureAISelector.cpp
+++ b/src/server/game/AI/CreatureAISelector.cpp
@@ -101,8 +101,9 @@ namespace FactorySelector
     MovementGenerator* SelectMovementGenerator(Unit* unit)
     {
         MovementGeneratorType type = IDLE_MOTION_TYPE;
-        if (unit->IsCreature())
-            type = unit->ToCreature()->GetDefaultMovementType();
+        if (Creature* creature = unit->ToCreature())
+            if (!creature->GetPlayerMovingMe())
+                type = unit->ToCreature()->GetDefaultMovementType();
 
         auto mv_factory = sMovementGeneratorRegistry->GetRegistryItem(type);
         return ASSERT_NOTNULL(mv_factory)->Create(unit);

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -496,28 +496,15 @@ void SmartAI::RemoveAuras()
 
 void SmartAI::EnterEvadeMode()
 {
-    if (!me->IsAlive() || me->IsInEvadeMode())
-        return;
-
     if (mEvadeDisabled)
     {
         GetScript()->ProcessEventsFor(SMART_EVENT_EVADE);
         return;
     }
 
-    RemoveAuras();
-
+    if (!_EnterEvadeMode())
+        return;
     me->AddUnitState(UNIT_STATE_EVADE);
-    me->DeleteThreatList();
-    me->ClearSaveThreatTarget();
-    me->CombatStop(true);
-    me->LoadCreaturesAddon();
-    me->SetLootRecipient(nullptr);
-    me->ResetPlayerDamageReq();
-
-    //me->m_Events.AddEvent(new SetImuneDelayEvent(*me), me->m_Events.CalculateTime(8000));
-    //me->SetReactState(REACT_PASSIVE);
-    //me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
 
     GetScript()->ProcessEventsFor(SMART_EVENT_EVADE);//must be after aura clear so we can cast spells from db
 
@@ -527,15 +514,24 @@ void SmartAI::EnterEvadeMode()
         AddEscortState(SMART_ESCORT_RETURNING);
         ReturnToLastOOCPos();
     }
-    else if (!mFollowGuid.IsEmpty())
+    else if (Unit* target = !mFollowGuid.IsEmpty() ? ObjectAccessor::GetUnit(*me, mFollowGuid) : nullptr)
     {
-        if (Unit* target = me->GetUnit(*me, mFollowGuid))
-            me->GetMotionMaster()->MoveFollow(target, mFollowDist, mFollowAngle);
+        me->GetMotionMaster()->MoveFollow(target, mFollowDist, mFollowAngle);
+
+        // evade is not cleared in MoveFollow, so we can't keep it
+        me->ClearUnitState(UNIT_STATE_EVADE);
+        GetScript()->OnReset();
+    }
+    else if (Unit* owner = me->GetCharmerOrOwner())
+    {
+        me->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+        me->ClearUnitState(UNIT_STATE_EVADE);
     }
     else
         me->GetMotionMaster()->MoveTargetedHome();
 
-    Reset();
+    if (!me->HasUnitState(UNIT_STATE_EVADE))
+        GetScript()->OnReset();
 }
 
 void SmartAI::MoveInLineOfSight(Unit* who)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -573,13 +573,6 @@ void SmartAI::MoveInLineOfSight(Unit* who)
     }
 }
 
-bool SmartAI::CanAIAttack(const Unit* /*who*/) const
-{
-    if (me->GetReactState() == REACT_PASSIVE)
-        return false;
-    return true;
-}
-
 uint32 SmartAI::GetWPCount()
 {
     return mWayPoints ? mWayPoints->size() : 0;

--- a/src/server/game/AI/SmartScripts/SmartAI.h
+++ b/src/server/game/AI/SmartScripts/SmartAI.h
@@ -144,9 +144,6 @@ class SmartAI : public CreatureAI
         // Called when creature gets charmed by another unit
         void OnCharmed(bool apply) override;
 
-        // Called when victim is in line of sight
-        bool CanAIAttack(const Unit* who) const override;
-
         // Used in scripts to share variables
         void DoAction(const int32 param = 0) override;
 

--- a/src/server/game/Combat/HostileRefManager.cpp
+++ b/src/server/game/Combat/HostileRefManager.cpp
@@ -21,19 +21,9 @@
 #include "Unit.h"
 #include "SpellInfo.h"
 
-HostileRefManager::HostileRefManager(Unit* owner)
-{
-    iOwner = owner;
-}
-
 HostileRefManager::~HostileRefManager()
 {
     deleteReferences();
-}
-
-Unit* HostileRefManager::getOwner()
-{
-    return iOwner;
 }
 
 void HostileRefManager::threatAssist(Unit* victim, float baseThreat, SpellInfo const* threatSpell)
@@ -190,7 +180,7 @@ void HostileRefManager::UpdateVisibility()
     while (ref)
     {
         HostileReference* nextRef = ref->next();
-        if (!ref->getSource()->getOwner()->canSeeOrDetect(getOwner()))
+        if (!ref->getSource()->getOwner()->canSeeOrDetect(GetOwner()))
         {
             ref->setOnlineOfflineState(false);
             nextRef = ref->next();

--- a/src/server/game/Combat/HostileRefManager.h
+++ b/src/server/game/Combat/HostileRefManager.h
@@ -28,13 +28,11 @@ class SpellInfo;
 
 class HostileRefManager : public RefManager<Unit, ThreatManager>
 {
-    Unit* iOwner;
-    std::recursive_mutex i_threat_lock;
 public:
-    explicit HostileRefManager(Unit* owner);
+    explicit HostileRefManager(Unit* owner) : iOwner(owner) { }
     ~HostileRefManager();
 
-    Unit* getOwner();
+    Unit* GetOwner() const { return iOwner; }
 
     void threatAssist(Unit* victim, float baseThreat, SpellInfo const* threatSpell = nullptr);
 
@@ -59,6 +57,10 @@ public:
     void deleteReference(Unit* creature);
 
     void UpdateVisibility();
+
+private:
+    Unit* iOwner;
+    std::recursive_mutex i_threat_lock;
 };
 
 #endif

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -196,15 +196,6 @@ void ThreatContainer::remove(HostileReference* hostileRef)
 
 void ThreatContainer::addReference(HostileReference* hostileRef)
 {
-    if (hostileRef->getUnitGuid().IsPlayer())
-    {
-        TC_LOG_INFO("server.loading", "ADDING PLAYER THREAT");
-    }
-    else
-    {
-        TC_LOG_INFO("server.loading", "ADDING NON-PLAYER THREAT");
-    }
-
     std::lock_guard<std::recursive_mutex> guard(i_threat_lock);
     iThreatList.push_back(hostileRef);
 }
@@ -388,11 +379,6 @@ void ThreatManager::clearReferences()
 
 void ThreatManager::addThreat(Unit* victim, float threat, SpellSchoolMask schoolMask, SpellInfo const* threatSpell)
 {
-    if (victim->IsPlayer())
-    {
-        TC_LOG_INFO("server.loading", "ADD_THREAT: PLAYER");
-    }
-
     if (!ThreatCalcHelper::isValidProcess(victim, getOwner(), threatSpell))
         return;
 

--- a/src/server/game/Combat/ThreatManager.cpp
+++ b/src/server/game/Combat/ThreatManager.cpp
@@ -99,16 +99,18 @@ void HostileReference::fireStatusChanged(ThreatRefStatusChangeEvent& threatRefSt
 
 void HostileReference::addThreat(float modThreat)
 {
+    if (!modThreat)
+        return;
+
     iThreat += modThreat;
+
     if (!isOnline())
         updateOnlineStatus();
-    if (modThreat != 0.0f)
-    {
-        ThreatRefStatusChangeEvent event(UEV_THREAT_REF_THREAT_CHANGE, this, modThreat);
-        fireStatusChanged(event);
-    }
 
-    if (isValid() && modThreat >= 0.0f)
+    ThreatRefStatusChangeEvent event(UEV_THREAT_REF_THREAT_CHANGE, this, modThreat);
+    fireStatusChanged(event);
+
+    if (isValid() && modThreat > 0.0f)
     {
         Unit* victimOwner = getTarget()->GetCharmerOrOwner();
         if (victimOwner && victimOwner->IsAlive())
@@ -116,57 +118,9 @@ void HostileReference::addThreat(float modThreat)
     }
 }
 
-void HostileReference::setThreat(float threat)
-{
-    addThreat(threat - getThreat());
-}
-
 void HostileReference::addThreatPercent(int32 percent)
 {
-    float tmpThreat = iThreat;
-    AddPct(tmpThreat, percent);
-    addThreat(tmpThreat - iThreat);
-}
-
-float HostileReference::getThreat() const
-{
-    return iThreat;
-}
-
-bool HostileReference::isOnline() const
-{
-    return iOnline;
-}
-
-bool HostileReference::isAccessible() const
-{
-    return iAccessible;
-}
-
-void HostileReference::setTempThreat(float threat)
-{
-    addTempThreat(threat - getThreat());
-}
-
-void HostileReference::addTempThreat(float threat)
-{
-    iTempThreatModifier = threat;
-    if (iTempThreatModifier != 0.0f)
-        addThreat(iTempThreatModifier);
-}
-
-void HostileReference::resetTempThreat()
-{
-    if (iTempThreatModifier != 0.0f)
-    {
-        addThreat(-iTempThreatModifier);
-        iTempThreatModifier = 0.0f;
-    }
-}
-
-float HostileReference::getTempThreatModifier()
-{
-    return iTempThreatModifier;
+    addThreat(CalculatePct(iThreat, percent));
 }
 
 void HostileReference::updateOnlineStatus()
@@ -192,6 +146,7 @@ void HostileReference::updateOnlineStatus()
                 accessible = true;
         }
     }
+
     setAccessibleState(accessible);
     setOnlineOfflineState(online);
 }
@@ -215,19 +170,9 @@ void HostileReference::setAccessibleState(bool isAccessible)
     {
         iAccessible = isAccessible;
 
-        ThreatRefStatusChangeEvent event(UEV_THREAT_REF_ASSECCIBLE_STATUS, this);
+        ThreatRefStatusChangeEvent event(UEV_THREAT_REF_ACCESSIBLE_STATUS, this);
         fireStatusChanged(event);
     }
-}
-
-bool HostileReference::operator==(const HostileReference& hostileRef) const
-{
-    return hostileRef.getUnitGuid() == getUnitGuid();
-}
-
-ObjectGuid HostileReference::getUnitGuid() const
-{
-    return iUnitGuid;
 }
 
 void HostileReference::removeReference()
@@ -236,11 +181,6 @@ void HostileReference::removeReference()
 
     ThreatRefStatusChangeEvent event(UEV_THREAT_REF_REMOVE_FROM_LIST, this);
     fireStatusChanged(event);
-}
-
-HostileReference* HostileReference::next()
-{
-    return dynamic_cast<HostileReference*>(Reference<Unit, ThreatManager>::next());
 }
 
 Unit* HostileReference::getSourceUnit()
@@ -256,6 +196,15 @@ void ThreatContainer::remove(HostileReference* hostileRef)
 
 void ThreatContainer::addReference(HostileReference* hostileRef)
 {
+    if (hostileRef->getUnitGuid().IsPlayer())
+    {
+        TC_LOG_INFO("server.loading", "ADDING PLAYER THREAT");
+    }
+    else
+    {
+        TC_LOG_INFO("server.loading", "ADDING NON-PLAYER THREAT");
+    }
+
     std::lock_guard<std::recursive_mutex> guard(i_threat_lock);
     iThreatList.push_back(hostileRef);
 }
@@ -439,6 +388,11 @@ void ThreatManager::clearReferences()
 
 void ThreatManager::addThreat(Unit* victim, float threat, SpellSchoolMask schoolMask, SpellInfo const* threatSpell)
 {
+    if (victim->IsPlayer())
+    {
+        TC_LOG_INFO("server.loading", "ADD_THREAT: PLAYER");
+    }
+
     if (!ThreatCalcHelper::isValidProcess(victim, getOwner(), threatSpell))
         return;
 
@@ -499,12 +453,16 @@ void ThreatManager::_addThreat(Unit* victim, float threat)
 
     if (!ref) // there was no ref => create a new one
     {
+        bool isFirst = iThreatContainer.empty();
+
         // threat has to be 0 here
         auto hostileRef = new HostileReference(victim, this, 0);
         iThreatContainer.addReference(hostileRef);
         hostileRef->addThreat(threat); // now we add the real threat
         if (victim->IsPlayer() && victim->ToPlayer()->isGameMaster())
             hostileRef->setOnlineOfflineState(false); // GM is always offline
+        else if (isFirst)
+            setCurrentVictim(hostileRef);
     }
 }
 

--- a/src/server/game/Combat/UnitEvents.cpp
+++ b/src/server/game/Combat/UnitEvents.cpp
@@ -18,26 +18,6 @@
 
 #include "UnitEvents.h"
 
-UnitBaseEvent::UnitBaseEvent(uint32 pType)
-{
-    iType = pType;
-}
-
-uint32 UnitBaseEvent::getType() const
-{
-    return iType;
-}
-
-bool UnitBaseEvent::matchesTypeMask(uint32 pMask) const
-{
-    return (iType & pMask) != 0;
-}
-
-void UnitBaseEvent::setType(uint32 pType)
-{
-    iType = pType;
-}
-
 ThreatRefStatusChangeEvent::ThreatRefStatusChangeEvent(uint32 pType): UnitBaseEvent(pType), iThreatManager(nullptr)
 {
     iHostileReference = nullptr;
@@ -93,22 +73,4 @@ void ThreatRefStatusChangeEvent::setThreatManager(ThreatManager* pThreatManager)
 ThreatManager* ThreatRefStatusChangeEvent::getThreatManager() const
 {
     return iThreatManager;
-}
-
-ThreatManagerEvent::ThreatManagerEvent(uint32 pType): ThreatRefStatusChangeEvent(pType), iThreatContainer(nullptr)
-{
-}
-
-ThreatManagerEvent::ThreatManagerEvent(uint32 pType, HostileReference* pHostileReference): ThreatRefStatusChangeEvent(pType, pHostileReference), iThreatContainer(nullptr)
-{
-}
-
-void ThreatManagerEvent::setThreatContainer(ThreatContainer* pThreatContainer)
-{
-    iThreatContainer = pThreatContainer;
-}
-
-ThreatContainer* ThreatManagerEvent::getThreatContainer() const
-{
-    return iThreatContainer;
 }

--- a/src/server/game/Combat/UnitEvents.h
+++ b/src/server/game/Combat/UnitEvents.h
@@ -37,7 +37,7 @@ enum UNIT_EVENT_TYPE
     UEV_THREAT_REF_REMOVE_FROM_LIST     = 1<<2,
 
     // Player/Pet entered/left  water or some other place where it is/was not accessible for the creature
-    UEV_THREAT_REF_ASSECCIBLE_STATUS    = 1<<3,
+    UEV_THREAT_REF_ACCESSIBLE_STATUS = 1<<3,
 
     // Threat list is going to be sorted (if dirty flag is set)
     UEV_THREAT_SORT_LIST                = 1<<4,
@@ -62,13 +62,16 @@ enum UNIT_EVENT_TYPE
 
 class UnitBaseEvent
 {
-    uint32 iType;
 public:
-    UnitBaseEvent(uint32 pType);
-    uint32 getType() const;
-    bool matchesTypeMask(uint32 pMask) const;
+    explicit UnitBaseEvent(uint32 pType) { iType = pType; }
+    uint32 getType() const { return iType; }
+    bool matchesTypeMask(uint32 pMask) const { return (iType & pMask) != 0; }
 
-    void setType(uint32 pType);
+private:
+    uint32 iType;
+
+protected:
+    ~UnitBaseEvent() { }
 };
 
 class ThreatRefStatusChangeEvent : public UnitBaseEvent
@@ -82,7 +85,7 @@ class ThreatRefStatusChangeEvent : public UnitBaseEvent
     };
     ThreatManager* iThreatManager;
 public:
-    ThreatRefStatusChangeEvent(uint32 pType);
+    explicit ThreatRefStatusChangeEvent(uint32 pType);
     ThreatRefStatusChangeEvent(uint32 pType, HostileReference* pHostileReference);
     ThreatRefStatusChangeEvent(uint32 pType, HostileReference* pHostileReference, float pValue);
     ThreatRefStatusChangeEvent(uint32 pType, HostileReference* pHostileReference, bool pValue);
@@ -96,17 +99,6 @@ public:
 
     void setThreatManager(ThreatManager* pThreatManager);
     ThreatManager* getThreatManager() const;
-};
-
-class ThreatManagerEvent : public ThreatRefStatusChangeEvent
-{
-    ThreatContainer* iThreatContainer;
-public:
-    ThreatManagerEvent(uint32 pType);
-    ThreatManagerEvent(uint32 pType, HostileReference* pHostileReference);
-
-    void setThreatContainer(ThreatContainer* pThreatContainer);
-    ThreatContainer* getThreatContainer() const;
 };
 
 #endif

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -752,6 +752,7 @@ class Creature : public Unit, public GridObject<Creature>, public MapObject
         void RemoveCorpse(bool setSpawnTime = true);
 
         void DespawnOrUnsummon(uint32 msTimeToDespawn = 0, Seconds const& forceRespawnTimer = Seconds::zero());
+        void DespawnOrUnsummon(Milliseconds time, Seconds forceRespawnTime = 0s) { DespawnOrUnsummon(uint32(time.count()), forceRespawnTime); }
 
         time_t const& GetRespawnTime() const { return m_respawnTime; }
         time_t GetRespawnTimeEx() const;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15873,7 +15873,7 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
         }
     }
 
-    if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved())) // unit controlled by a player.
+    if (Player* playerMover = GetPlayerMovingMe()) // unit controlled by a player.
     {
         // Send notification to self
         WorldPackets::Movement::MoveSetSpeed selfpacket(moveTypeToOpcode[mtype][1]);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11391,6 +11391,11 @@ bool Unit::Attack(Unit* victim, bool meleeAttack)
     if (IsPlayer() && IsMounted() && !HasFlag(UNIT_FIELD_FLAGS_3, UNIT_FLAG3_NOT_CHECK_MOUNT))
         return false;
 
+    Creature* creature = ToCreature();
+    // creatures cannot attack while evading
+    if (creature && creature->IsInEvadeMode())
+        return false;
+
     // nobody can attack GM in GM-mode
     if (victim->IsPlayer())
     {
@@ -16209,10 +16214,9 @@ Unit* Creature::SelectVictim()
 
     // last case when creature must not go to evade mode:
     // it in combat but attacker not make any damage and not enter to aggro radius to have record in threat list
-    // for example at owner command to pet attack some far away creature
     // Note: creature does not have targeted movement generator but has attacker in this case
     for (UnitSet::iterator itr = m_attackers.begin(); itr != m_attackers.end(); ++itr)
-        if ((*itr) && !canCreatureAttack(*itr) && !(*itr)->IsPlayer() && !(*itr)->ToCreature()->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
+        if ((*itr) && canCreatureAttack(*itr) && !(*itr)->IsPlayer() && !(*itr)->ToCreature()->HasUnitTypeMask(UNIT_MASK_CONTROLABLE_GUARDIAN))
             return nullptr;
 
     // TODO: a vehicle may eat some mob, so mob should not evade

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -1208,7 +1208,6 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
             if (victim != this && victim->IsPlayer() && (!spellProto || !(spellProto->HasAttribute(SPELL_ATTR7_NO_PUSHBACK_ON_DAMAGE) || spellProto->IsTargetingArea() || (cleanDamage ? cleanDamage->isAoe : false))))
             {
                 if (damagetype != DOT)
-                {
                     if (Spell* spell = victim->m_currentSpells[CURRENT_GENERIC_SPELL])
                         if (spell->getState() == SPELL_STATE_PREPARING)
                         {
@@ -1218,7 +1217,10 @@ uint32 Unit::DealDamage(Unit* victim, uint32 damage, CleanDamage const* cleanDam
                             else if (interruptFlags & SPELL_INTERRUPT_FLAG_PUSH_BACK)
                                 spell->Delayed();
                         }
-                }
+
+                if (Spell* spell = victim->m_currentSpells[CURRENT_CHANNELED_SPELL])
+                    if (spell->getState() == SPELL_STATE_CASTING && spell->m_spellInfo->HasChannelInterruptFlag(CHANNEL_INTERRUPT_FLAG_FLAG_DELAY) && damagetype != DOT)
+                        spell->DelayedChannel();
             }
         }
 
@@ -16246,7 +16248,6 @@ Unit* Creature::SelectVictim()
         return nullptr;
     }
 
-    TC_LOG_INFO("server.loading", "EVADING");
     // enter in evade mode in other case
     AI()->EnterEvadeMode();
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16165,9 +16165,29 @@ Unit* Creature::SelectVictim()
 
     if (CanHaveThreatList())
     {
+        if (target && target->GetEntry() == 42601)
+        {
+            TC_LOG_INFO("server.loading", "0 - TARGETING VEHICLE");
+        }
+
+        if (target && target->IsPlayer())
+        {
+            TC_LOG_INFO("server.loading", "0 - TARGETING PLAYER");
+        }
+
         if (!target && !m_ThreatManager.isThreatListEmpty())
             // No taunt aura or taunt aura caster is dead standard target selection
             target = m_ThreatManager.getHostilTarget();
+
+        if (target && target->GetEntry() == 42601)
+        {
+            TC_LOG_INFO("server.loading", "1 - TARGETING VEHICLE");
+        }
+
+        if (target && target->IsPlayer())
+        {
+            TC_LOG_INFO("server.loading", "1 - TARGETING PLAYER");
+        }
 
         //If target in agrolist check onli friend
         if (target && !IsFriendlyTo(target) && canCreatureAttack(target))
@@ -16206,6 +16226,16 @@ Unit* Creature::SelectVictim()
     else
         return nullptr;
 
+    if (target && target->GetEntry() == 42601)
+    {
+        TC_LOG_INFO("server.loading", "2 - TARGETING VEHICLE");
+    }
+
+    if (target && target->IsPlayer())
+    {
+        TC_LOG_INFO("server.loading", "2 - TARGETING PLAYER");
+    }
+
     if (target && _IsTargetAcceptable(target) && canCreatureAttack(target))
     {
         SetInFront(target);
@@ -16228,6 +16258,16 @@ Unit* Creature::SelectVictim()
     {
         target = SelectNearestTargetInAttackDistance(m_CombatDistance ? m_CombatDistance : ATTACK_DISTANCE);
 
+        if (target && target->GetEntry() == 42601)
+        {
+            TC_LOG_INFO("server.loading", "3 - TARGETING VEHICLE");
+        }
+
+        if (target && target->IsPlayer())
+        {
+            TC_LOG_INFO("server.loading", "3 - TARGETING PLAYER");
+        }
+
         if (target && _IsTargetAcceptable(target) && canCreatureAttack(target))
             return target;
     }
@@ -16246,6 +16286,7 @@ Unit* Creature::SelectVictim()
         return nullptr;
     }
 
+    TC_LOG_INFO("server.loading", "EVADING");
     // enter in evade mode in other case
     AI()->EnterEvadeMode();
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -16165,29 +16165,9 @@ Unit* Creature::SelectVictim()
 
     if (CanHaveThreatList())
     {
-        if (target && target->GetEntry() == 42601)
-        {
-            TC_LOG_INFO("server.loading", "0 - TARGETING VEHICLE");
-        }
-
-        if (target && target->IsPlayer())
-        {
-            TC_LOG_INFO("server.loading", "0 - TARGETING PLAYER");
-        }
-
         if (!target && !m_ThreatManager.isThreatListEmpty())
             // No taunt aura or taunt aura caster is dead standard target selection
             target = m_ThreatManager.getHostilTarget();
-
-        if (target && target->GetEntry() == 42601)
-        {
-            TC_LOG_INFO("server.loading", "1 - TARGETING VEHICLE");
-        }
-
-        if (target && target->IsPlayer())
-        {
-            TC_LOG_INFO("server.loading", "1 - TARGETING PLAYER");
-        }
 
         //If target in agrolist check onli friend
         if (target && !IsFriendlyTo(target) && canCreatureAttack(target))
@@ -16226,16 +16206,6 @@ Unit* Creature::SelectVictim()
     else
         return nullptr;
 
-    if (target && target->GetEntry() == 42601)
-    {
-        TC_LOG_INFO("server.loading", "2 - TARGETING VEHICLE");
-    }
-
-    if (target && target->IsPlayer())
-    {
-        TC_LOG_INFO("server.loading", "2 - TARGETING PLAYER");
-    }
-
     if (target && _IsTargetAcceptable(target) && canCreatureAttack(target))
     {
         SetInFront(target);
@@ -16257,16 +16227,6 @@ Unit* Creature::SelectVictim()
     if (HasReactState(REACT_AGGRESSIVE))
     {
         target = SelectNearestTargetInAttackDistance(m_CombatDistance ? m_CombatDistance : ATTACK_DISTANCE);
-
-        if (target && target->GetEntry() == 42601)
-        {
-            TC_LOG_INFO("server.loading", "3 - TARGETING VEHICLE");
-        }
-
-        if (target && target->IsPlayer())
-        {
-            TC_LOG_INFO("server.loading", "3 - TARGETING PLAYER");
-        }
 
         if (target && _IsTargetAcceptable(target) && canCreatureAttack(target))
             return target;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17495,8 +17495,13 @@ void Unit::CleanupsBeforeDelete(bool finalCleanup)
 void Unit::SetMovedUnit(Unit* target)
 {
     m_unitMovedByMe->m_playerMovingMe = nullptr;
+    if (m_unitMovedByMe->GetTypeId() == TYPEID_UNIT)
+        m_unitMovedByMe->GetMotionMaster()->Initialize();
+
     m_unitMovedByMe = ASSERT_NOTNULL(target);
     m_unitMovedByMe->m_playerMovingMe = ASSERT_NOTNULL(ToPlayer());
+    if (m_unitMovedByMe->GetTypeId() == TYPEID_UNIT)
+        m_unitMovedByMe->GetMotionMaster()->Initialize();
 
     WorldPackets::Movement::MoveSetActiveMover packet;
     packet.MoverGUID = target->GetGUID();
@@ -25431,15 +25436,16 @@ void Unit::BuildValuesUpdate(uint8 updateType, ByteBuffer* data, Player* target)
                 }
 
                 // TOS: The Desolate Host
-                if (dynamicFlags & UNIT_DYNFLAG_NOT_SELECTABLE_MODEL)
-                {
-                    if (target == this
-                        || HasAura(235734) && target->HasAura(235734) || HasAura(235732) && target->HasAura(235732)
-                        || target->HasAura(235734) && HasAura(235113) || target->HasAura(235732) && HasAura(235620))
-                    {
-                        dynamicFlags &= ~UNIT_DYNFLAG_NOT_SELECTABLE_MODEL;
-                    }
-                }
+                // TODO: this dynflag doesn't seem to exist in any other cores
+//                if (dynamicFlags & UNIT_DYNFLAG_NOT_SELECTABLE_MODEL)
+//                {
+//                    if (target == this
+//                        || HasAura(235734) && target->HasAura(235734) || HasAura(235732) && target->HasAura(235732)
+//                        || target->HasAura(235734) && HasAura(235113) || target->HasAura(235732) && HasAura(235620))
+//                    {
+//                        dynamicFlags &= ~UNIT_DYNFLAG_NOT_SELECTABLE_MODEL;
+//                    }
+//                }
 
                 // unit UNIT_DYNFLAG_TRACK_UNIT should only be sent to caster of SPELL_AURA_MOD_STALKED auras
                 if (dynamicFlags & UNIT_DYNFLAG_TRACK_UNIT)

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -151,7 +151,7 @@ enum UnitFlags : uint32
     UNIT_FLAG_SKINNABLE             = 0x04000000,
     UNIT_FLAG_MOUNT                 = 0x08000000,
     UNIT_FLAG_PREVENT_KNEELING_WHEN_LOOTING = 0x10000000,
-    UNIT_FLAG_PREVENT_EMOTES        = 0x20000000,           // used in Feing Death spell
+    UNIT_FLAG_PREVENT_EMOTES        = 0x20000000,           // used in Feign Death spell
     UNIT_FLAG_SHEATHE               = 0x40000000,
     UNIT_FLAG_UNK_31                = 0x80000000
 };

--- a/src/server/game/Maps/MapRefManager.h
+++ b/src/server/game/Maps/MapRefManager.h
@@ -26,20 +26,16 @@ class MapReference;
 class MapRefManager : public RefManager<Map, Player>
 {
     public:
-        typedef LinkedListHead::Iterator< MapReference > iterator;
-        typedef LinkedListHead::Iterator< MapReference const > const_iterator;
+        typedef LinkedListHead::Iterator<MapReference> iterator;
+        typedef LinkedListHead::Iterator<MapReference const> const_iterator;
 
         MapReference* getFirst() { return (MapReference*)RefManager<Map, Player>::getFirst(); }
         MapReference const* getFirst() const { return (MapReference const*)RefManager<Map, Player>::getFirst(); }
-        MapReference* getLast() { return (MapReference*)RefManager<Map, Player>::getLast(); }
-        MapReference const* getLast() const { return (MapReference const*)RefManager<Map, Player>::getLast(); }
 
         iterator begin() { return iterator(getFirst()); }
-        iterator end() { return iterator(NULL); }
-        iterator rbegin() { return iterator(getLast()); }
-        iterator rend() { return iterator(NULL); }
+        iterator end() { return iterator(nullptr); }
         const_iterator begin() const { return const_iterator(getFirst()); }
-        const_iterator end() const  { return const_iterator(NULL); }
+        const_iterator end() const  { return const_iterator(nullptr); }
 };
 #endif
 

--- a/src/server/game/Miscellaneous/SharedDefines.h
+++ b/src/server/game/Miscellaneous/SharedDefines.h
@@ -4532,14 +4532,15 @@ enum TotemCategory
 enum UnitDynFlags
 {
     UNIT_DYNFLAG_NONE                       = 0x0000,
-    UNIT_DYNFLAG_HIDE_MODEL                 = 0x0001, // Object model is not shown with this flag
-    UNIT_DYNFLAG_NOT_SELECTABLE_MODEL       = 0x0002,
+    UNIT_DYNFLAG_HIDE_MODEL                 = 0x0002, // Object model is not shown with this flag
     UNIT_DYNFLAG_LOOTABLE                   = 0x0004,
     UNIT_DYNFLAG_TRACK_UNIT                 = 0x0008,
     UNIT_DYNFLAG_TAPPED                     = 0x0010, // Lua_UnitIsTapped
     UNIT_DYNFLAG_SPECIALINFO                = 0x0020,
-    UNIT_DYNFLAG_REFER_A_FRIEND             = 0x0040,
-    UNIT_DYNFLAG_DISABLE_SAME_INTARACT      = 0x0080  // Example: seat on friend mount
+    UNIT_DYNFLAG_DEAD                       = 0x0040,
+    UNIT_DYNFLAG_REFER_A_FRIEND             = 0x0080,
+
+    UNIT_DYNFLAG_DISABLE_SAME_INTARACT      = 0x0100  // Example: seat on friend mount ?????
 };
 
 enum CorpseDynFlags

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -6158,28 +6158,6 @@ void AuraEffect::HandleAuraDummy(AuraApplication const* aurApp, uint8 mode, bool
                 break;
             switch (GetId())
             {
-                // Permanent Feign Death
-                case 96733: //Permanent Feign Death (Stun)
-                // Use it every time when we have port spawn
-                //DELETE FROM creature_template_addon WHERE entry in(SELECT id FROM `creature` WHERE guid in(SELECT guid FROM `creature_addon` WHERE `auras` LIKE '%29266%'));
-                //UPDATE creature_template SET `unit_flags` = `unit_flags` & ~(256 | 512 | 262144 | 536870912) where entry in(SELECT id FROM `creature` WHERE guid in(SELECT guid FROM `creature_addon` WHERE `auras` LIKE '%29266%'));
-                case 29266:
-                    if (!target)
-                        break;
-                    
-                    if (apply)
-                    {
-                        target->SetUInt32Value(OBJECT_FIELD_DYNAMIC_FLAGS, 0x64);
-                        target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES | UNIT_FLAG_UNK_15 | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_IMMUNE_TO_PC);
-                        target->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
-                    }
-                    else
-                    {
-                        target->SetUInt32Value(OBJECT_FIELD_DYNAMIC_FLAGS, 0);
-                        target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES | UNIT_FLAG_UNK_15 | UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_IMMUNE_TO_PC);
-                        target->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
-                    }
-                    break;
                 // Recently Bandaged
                 case 11196:
                     target->ApplySpellImmune(GetId(), IMMUNITY_MECHANIC, GetMiscValue(), apply);

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -3375,13 +3375,15 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
         target->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES);
         target->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
         target->SetFlag(UNIT_FIELD_FLAGS_3, UNIT_FLAG3_FEIGN_DEATH);
+        target->SetFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->AddUnitState(UNIT_STATE_DIED);
 
         if (auto creature = target->ToCreature())
         {
-            creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
-            creature->StopAttack();
-            creature->RemoveAurasAllDots();
+            //creature->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
+            //creature->StopAttack();
+            //creature->RemoveAurasAllDots();
+            creature->SetReactState(REACT_PASSIVE);
         }
     }
     else
@@ -3389,11 +3391,12 @@ void AuraEffect::HandleFeignDeath(AuraApplication const* aurApp, uint8 mode, boo
         target->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PREVENT_EMOTES);
         target->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
         target->RemoveFlag(UNIT_FIELD_FLAGS_3, UNIT_FLAG3_FEIGN_DEATH);
+        target->RemoveFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
         target->ClearUnitState(UNIT_STATE_DIED);
 
         if (auto creature = target->ToCreature())
         {
-            creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
+            //creature->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
             creature->InitializeReactState();
         }
 

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -980,8 +980,6 @@ public:
 
                 if (dynamicFlags & UNIT_DYNFLAG_HIDE_MODEL)
                     ss_flags << "HideModel ";
-                if (dynamicFlags & UNIT_DYNFLAG_NOT_SELECTABLE_MODEL)
-                    ss_flags << "NotSlectableModel ";
                 if (dynamicFlags & UNIT_DYNFLAG_LOOTABLE)
                     ss_flags << "Lootable ";
                 if (dynamicFlags & UNIT_DYNFLAG_TRACK_UNIT)
@@ -990,6 +988,8 @@ public:
                     ss_flags << "Tapped ";
                 if (dynamicFlags & UNIT_DYNFLAG_SPECIALINFO)
                     ss_flags << "SpecialInfo ";
+                if (dynamicFlags & UNIT_DYNFLAG_DEAD)
+                    ss_flags << "Dead ";
                 if (dynamicFlags & UNIT_DYNFLAG_REFER_A_FRIEND)
                     ss_flags << "ReferFriend ";
                 if (dynamicFlags & UNIT_DYNFLAG_DISABLE_SAME_INTARACT)

--- a/src/server/scripts/EasternKingdoms/zone_westfall.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_westfall.cpp
@@ -330,10 +330,147 @@ public:
 
 };
 
+class spell_westfall_unbound_energy : public SpellScript
+{
+    PrepareSpellScript(spell_westfall_unbound_energy);
+
+    void FilterTargets(std::list<WorldObject*>& targets)
+    {
+        if (targets.empty())
+            return;
+
+        Unit* caster = GetCaster();
+        targets.remove_if([caster](WorldObject const* target)->bool
+        {
+            return caster == target;
+        });
+
+        if (targets.size() > 1)
+            Trinity::Containers::RandomResizeList(targets, 1);
+    }
+
+    void Register() override
+    {
+        OnObjectAreaTargetSelect += SpellObjectAreaTargetSelectFn(spell_westfall_unbound_energy::FilterTargets, EFFECT_0, TARGET_UNIT_SRC_AREA_ENTRY);
+    }
+};
+
+enum ItsAlive
+{
+    // Events
+    EVENT_CHECK_AREA                = 1,
+    EVENT_DESPAWN_HARVESTER         = 2,
+
+    // Texts
+    SAY_ANNOUNCE_OUT_OF_AREA        = 0,
+
+    // Area Ids
+    AREA_ID_THE_MOEST_FARM          = 918,
+
+    // Creatures
+    NPC_ENERGIZED_HARVEST_REAPER    = 42342,
+    NPC_OVERLOADED_HARVEST_GOLEM    = 42601
+};
+
+struct npc_westfall_overloaded_harvest_golem : public VehicleAI
+{
+    npc_westfall_overloaded_harvest_golem(Creature* creature) : VehicleAI(creature) { }
+
+    void JustRespawned() override
+    {
+        _events.ScheduleEvent(EVENT_CHECK_AREA, 1s);
+    }
+
+    void UpdateAI(uint32 diff) override
+    {
+        _events.Update(diff);
+        while (uint32 eventId = _events.ExecuteEvent())
+        {
+            switch (eventId)
+            {
+                case EVENT_CHECK_AREA:
+                    if (me->GetAreaId() != AREA_ID_THE_MOEST_FARM)
+                    {
+                        if (Unit* owner = me->GetCharmerOrOwner())
+                            Talk(SAY_ANNOUNCE_OUT_OF_AREA, owner->GetGUID());
+                        _events.ScheduleEvent(EVENT_DESPAWN_HARVESTER, 8s);
+                    }
+                    else
+                        _events.Repeat(1s);
+                    break;
+                case EVENT_DESPAWN_HARVESTER:
+                    if (me->GetAreaId() != AREA_ID_THE_MOEST_FARM)
+                        me->DespawnOrUnsummon();
+                    else
+                        _events.ScheduleEvent(EVENT_CHECK_AREA, 1s);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+private:
+    EventMap _events;
+};
+
+class spell_westfall_reaping_blows : public AuraScript
+{
+    PrepareAuraScript(spell_westfall_reaping_blows);
+
+    void HandlePeriodic(AuraEffect const* /*aurEff*/)
+    {
+        PreventDefaultAction();
+        if (Creature* reaper = GetTarget()->FindNearestCreature(NPC_ENERGIZED_HARVEST_REAPER, 5.f, true))
+            GetTarget()->CastSpell(reaper, GetSpellInfo()->Effects[EFFECT_1]->TriggerSpell, true);
+    }
+
+    void Register() override
+    {
+        OnEffectPeriodic += AuraEffectPeriodicFn(spell_westfall_reaping_blows::HandlePeriodic, EFFECT_1, SPELL_AURA_PERIODIC_TRIGGER_SPELL);
+    }
+};
+
+class spell_westfall_wake_harvest_golem : public SpellScript
+{
+    PrepareSpellScript(spell_westfall_wake_harvest_golem);
+
+    SpellCastResult CheckTarget()
+    {
+        Unit* target = GetExplTargetUnit();
+        if (!target || !target->IsCreature())
+            return SPELL_FAILED_BAD_TARGETS;
+
+        return SPELL_CAST_OK;
+    }
+
+    void HandleScriptEffect(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->IsPlayer())
+            return;
+
+        if (Creature* target = GetHitCreature())
+        {
+            caster->ToPlayer()->KilledMonsterCredit(NPC_OVERLOADED_HARVEST_GOLEM);
+            target->DespawnOrUnsummon(100ms);
+        }
+    }
+
+    void Register() override
+    {
+        OnCheckCast += SpellCheckCastFn(spell_westfall_wake_harvest_golem::CheckTarget);
+        OnEffectHitTarget += SpellEffectFn(spell_westfall_wake_harvest_golem::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
 
 void AddSC_westfall()
 {
     new npc_daphne_stilwell();
     new npc_defias_traitor();
     new npc_westfall_stew();
+    RegisterSpellScript(spell_westfall_unbound_energy);
+    RegisterCreatureAI(npc_westfall_overloaded_harvest_golem);
+    RegisterAuraScript(spell_westfall_reaping_blows);
+    RegisterSpellScript(spell_westfall_wake_harvest_golem);
 }

--- a/src/server/scripts/EasternKingdoms/zone_westfall.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_westfall.cpp
@@ -376,7 +376,7 @@ struct npc_westfall_overloaded_harvest_golem : public VehicleAI
 {
     npc_westfall_overloaded_harvest_golem(Creature* creature) : VehicleAI(creature) { }
 
-    void JustRespawned() override
+    void Reset() override
     {
         _events.ScheduleEvent(EVENT_CHECK_AREA, 1s);
     }

--- a/src/server/scripts/Legion/TombOfSargeras/boss_TheDesolateHost.cpp
+++ b/src/server/scripts/Legion/TombOfSargeras/boss_TheDesolateHost.cpp
@@ -1844,7 +1844,7 @@ class spell_tos_spiritual_barrier_dissonance : public AuraScript
     {
         if (GetTarget())
         {
-            GetTarget()->SetFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_NOT_SELECTABLE_MODEL);
+            GetTarget()->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
 
             if (GetTarget()->IsPlayer())
             {
@@ -1896,7 +1896,7 @@ class spell_tos_spiritual_barrier_dissonance : public AuraScript
     {
         if (GetTarget())
         {
-            GetTarget()->RemoveFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_NOT_SELECTABLE_MODEL);
+            GetTarget()->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
 
             if (GetTarget()->IsPlayer())
                 GetTarget()->ToPlayer()->UpdateCustomField();

--- a/src/server/scripts/Spells/spell_generic.cpp
+++ b/src/server/scripts/Spells/spell_generic.cpp
@@ -769,16 +769,23 @@ class spell_creature_permanent_feign_death : public SpellScriptLoader
             void HandleEffectApply(AuraEffect const* /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
+                target->SetFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
                 target->SetFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+                target->SetFlag(UNIT_FIELD_FLAGS_3, UNIT_FLAG3_FEIGN_DEATH);
 
-                if (target->GetTypeId() == TYPEID_UNIT)
-                    target->ToCreature()->SetReactState(REACT_PASSIVE);
+                if (Creature* creature = target->ToCreature())
+                    creature->SetReactState(REACT_PASSIVE);
             }
 
             void HandleEffectRemove(AuraEffect const * /*aurEff*/, AuraEffectHandleModes /*mode*/)
             {
                 Unit* target = GetTarget();
+                target->RemoveFlag(OBJECT_FIELD_DYNAMIC_FLAGS, UNIT_DYNFLAG_DEAD);
                 target->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_FEIGN_DEATH);
+                target->RemoveFlag(UNIT_FIELD_FLAGS_3, UNIT_FLAG3_FEIGN_DEATH);
+
+                if (Creature* creature = target->ToCreature())
+                    creature->InitializeReactState();
             }
 
             void Register() override

--- a/src/server/shared/Dynamic/LinkedList.h
+++ b/src/server/shared/Dynamic/LinkedList.h
@@ -33,17 +33,16 @@ class LinkedListElement
         LinkedListElement* iNext;
         LinkedListElement* iPrev;
     public:
-        LinkedListElement() : iNext(NULL), iPrev(NULL) { }
-        virtual ~LinkedListElement() { delink(); }
+        LinkedListElement() : iNext(nullptr), iPrev(nullptr) { }
 
-        bool hasNext() const { return(iNext && iNext->iNext != NULL); }
-        bool hasPrev() const { return(iPrev && iPrev->iPrev != NULL); }
-        bool isInList() const { return(iNext != NULL && iPrev != NULL); }
+        bool hasNext() const { return(iNext && iNext->iNext != nullptr); }
+        bool hasPrev() const { return(iPrev && iPrev->iPrev != nullptr); }
+        bool isInList() const { return(iNext != nullptr && iPrev != nullptr); }
 
-        LinkedListElement      * next()       { return hasNext() ? iNext : NULL; }
-        LinkedListElement const* next() const { return hasNext() ? iNext : NULL; }
-        LinkedListElement      * prev()       { return hasPrev() ? iPrev : NULL; }
-        LinkedListElement const* prev() const { return hasPrev() ? iPrev : NULL; }
+        LinkedListElement      * next()       { return hasNext() ? iNext : nullptr; }
+        LinkedListElement const* next() const { return hasNext() ? iNext : nullptr; }
+        LinkedListElement      * prev()       { return hasPrev() ? iPrev : nullptr; }
+        LinkedListElement const* prev() const { return hasPrev() ? iPrev : nullptr; }
 
         LinkedListElement      * nocheck_next()       { return iNext; }
         LinkedListElement const* nocheck_next() const { return iNext; }
@@ -52,10 +51,13 @@ class LinkedListElement
 
         void delink()
         {
-            if (isInList())
-            {
-                iNext->iPrev = iPrev; iPrev->iNext = iNext; iNext = NULL; iPrev = NULL;
-            }
+            if (!isInList())
+                return;
+
+            iNext->iPrev = iPrev;
+            iPrev->iNext = iNext;
+            iNext = nullptr;
+            iPrev = nullptr;
         }
 
         void insertBefore(LinkedListElement* pElem)
@@ -75,8 +77,14 @@ class LinkedListElement
         }
 
     private:
-        LinkedListElement(LinkedListElement const&);
-        LinkedListElement& operator=(LinkedListElement const&);
+        LinkedListElement(LinkedListElement const&) = delete;
+        LinkedListElement& operator=(LinkedListElement const&) = delete;
+
+    protected:
+        ~LinkedListElement()
+        {
+            delink();
+        }
 };
 
 //============================================
@@ -97,15 +105,13 @@ class LinkedListHead
             iLast.iPrev = &iFirst;
         }
 
-        virtual ~LinkedListHead() { }
-
         bool isEmpty() const { return(!iFirst.iNext->isInList()); }
 
-        LinkedListElement      * getFirst()       { return(isEmpty() ? NULL : iFirst.iNext); }
-        LinkedListElement const* getFirst() const { return(isEmpty() ? NULL : iFirst.iNext); }
+        LinkedListElement      * getFirst()       { return(isEmpty() ? nullptr : iFirst.iNext); }
+        LinkedListElement const* getFirst() const { return(isEmpty() ? nullptr : iFirst.iNext); }
 
-        LinkedListElement      * getLast() { return(isEmpty() ? NULL : iLast.iPrev); }
-        LinkedListElement const* getLast() const  { return(isEmpty() ? NULL : iLast.iPrev); }
+        LinkedListElement      * getLast() { return(isEmpty() ? nullptr : iLast.iPrev); }
+        LinkedListElement const* getLast() const  { return(isEmpty() ? nullptr : iLast.iPrev); }
 
         void insertFirst(LinkedListElement* pElem)
         {
@@ -248,8 +254,11 @@ class LinkedListHead
         typedef Iterator<LinkedListElement> iterator;
 
     private:
-        LinkedListHead(LinkedListHead const&);
-        LinkedListHead& operator=(LinkedListHead const&);
+        LinkedListHead(LinkedListHead const&) = delete;
+        LinkedListHead& operator=(LinkedListHead const&) = delete;
+
+    protected:
+        ~LinkedListHead() { }
 };
 
 //============================================

--- a/src/server/shared/Dynamic/LinkedReference/RefManager.h
+++ b/src/server/shared/Dynamic/LinkedReference/RefManager.h
@@ -26,28 +26,24 @@
 template <class TO, class FROM> class RefManager : public LinkedListHead
 {
     public:
-        typedef LinkedListHead::Iterator< Reference<TO, FROM> > iterator;
+        typedef LinkedListHead::Iterator<Reference<TO, FROM>> iterator;
         RefManager() { }
-        virtual ~RefManager() { clearReferences(); }
 
         Reference<TO, FROM>* getFirst() { return ((Reference<TO, FROM>*) LinkedListHead::getFirst()); }
         Reference<TO, FROM> const* getFirst() const { return ((Reference<TO, FROM> const*) LinkedListHead::getFirst()); }
-        Reference<TO, FROM>* getLast() { return ((Reference<TO, FROM>*) LinkedListHead::getLast()); }
-        Reference<TO, FROM> const* getLast() const { return ((Reference<TO, FROM> const*) LinkedListHead::getLast()); }
 
         iterator begin() { return iterator(getFirst()); }
-        iterator end() { return iterator(NULL); }
-        iterator rbegin() { return iterator(getLast()); }
-        iterator rend() { return iterator(NULL); }
+        iterator end() { return iterator(nullptr); }
+
+        virtual ~RefManager()
+        {
+            clearReferences();
+        }
 
         void clearReferences()
         {
-            LinkedListElement* ref;
-            while ((ref = getFirst()) != NULL)
-            {
-                ((Reference<TO, FROM>*) ref)->invalidate();
-                ref->delink();                              // the delink might be already done by invalidate(), but doing it here again does not hurt and insures an empty list
-            }
+            while (Reference<TO, FROM>* ref = getFirst())
+                ref->invalidate();
         }
 };
 

--- a/src/server/shared/Dynamic/LinkedReference/Reference.h
+++ b/src/server/shared/Dynamic/LinkedReference/Reference.h
@@ -29,6 +29,7 @@ template <class TO, class FROM> class Reference : public LinkedListElement
     private:
         TO* iRefTo;
         FROM* iRefFrom;
+
     protected:
         // Tell our refTo (target) object that we have a link
         virtual void targetObjectBuildLink() = 0;
@@ -90,14 +91,14 @@ template <class TO, class FROM> class Reference : public LinkedListElement
         Reference<TO, FROM>       * nocheck_prev()       { return((Reference<TO, FROM>       *) LinkedListElement::nocheck_prev()); }
         Reference<TO, FROM> const* nocheck_prev() const { return((Reference<TO, FROM> const*) LinkedListElement::nocheck_prev()); }
 
-        TO* operator ->() const { return iRefTo; }
+        TO* operator->() const { return iRefTo; }
         TO* getTarget() const { return iRefTo; }
 
         FROM* getSource() const { return iRefFrom; }
 
     private:
-        Reference(Reference const&);
-        Reference& operator=(Reference const&);
+        Reference(Reference const&) = delete;
+        Reference& operator=(Reference const&) = delete;
 };
 
 //=====================================================


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes permanent feign death spells so creatures appear dead in game, e.g. https://www.wowhead.com/npc=42381/overloaded-harvest-golem
- Adds Overloaded Harvest Golem visual effects
  - Ref: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/7f6e63f850aaf71668dedd8394f023eff2ef8452
- Adds spell scripts for entering vehicle, despawning Overloaded Harvest Golem, and Reaping Blows ability
  - Ref: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/445c018e6b6444cfe1cd3b9f7c10ec71f40563af
- Fixes speed change opcode in vehicles (use `SMSG_MOVE_SET_*` instead of `SMSG_MOVE_SPLINE_SET_*`)
  - This fixes https://www.wowhead.com/spell=79430/rocket-boost
- Minor threat system update to fix evading
  - Ref: https://github.com/TrinityCore/TrinityCore/commit/ec3dc0a43101dcbe2e469891acf0b654106eccfc

**Issues addressed:**

Helps with #188 

**Tests performed:**

tested in-game

**Known issues and TODO list:**

- [x] Rocket boost only seems to work properly when the player is NOT moving
- [x] Area check script doesn't work properly
- [x] https://www.wowhead.com/npc=42342/energized-harvest-reaper evades unexpectedly
- [ ] https://www.wowhead.com/spell=79425/reaping-blows does not show channeled cast bar


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
