### PR TITLE
Core/CreatureText: fix sound selection logic

### DIFF
--- a/src/server/game/Texts/CreatureTextMgr.cpp
+++ b/src/server/game/Texts/CreatureTextMgr.cpp
@@ -283,7 +283,7 @@ void CreatureTextMgr::SendText(Creature* source, CreatureTextEntry const* text, 
             if (gender == GENDER_NONE)
                 gender = source->getGender();
 
-            if (uint32 broadcastTextSoundId = bct->SoundEntriesID[gender == GENDER_MALE ? 0 : 1])
+            if (uint32 broadcastTextSoundId = bct->SoundEntriesID[gender == GENDER_FEMALE ? 1 : 0])
                 finalSound = broadcastTextSoundId;
         }
 

--- a/src/server/game/Texts/CreatureTextMgr.cpp
+++ b/src/server/game/Texts/CreatureTextMgr.cpp
@@ -272,18 +272,22 @@ void CreatureTextMgr::SendText(Creature* source, CreatureTextEntry const* text, 
 
     uint32 fSound = [bct, sound, source, text]() -> uint32
     {
-        uint8 gender = GENDER_NONE;
-        if (CreatureDisplayInfoEntry const* creatureDisplay = sCreatureDisplayInfoStore.LookupEntry(source->GetDisplayId()))
-            gender = creatureDisplay->Gender;
-        if (gender == GENDER_NONE)
-            gender = source->getGender();
-
-        if (!sound && bct)
-            return gender == GENDER_FEMALE ? bct->SoundEntriesID[1] : bct->SoundEntriesID[0];
-
+        uint32 finalSound = text->sound;
         if (sound)
-            return sound;
-        return text->sound;
+            finalSound = sound;
+        else if (bct)
+        {
+            uint8 gender = GENDER_NONE;
+            if (CreatureDisplayInfoEntry const* creatureDisplay = sCreatureDisplayInfoStore.LookupEntry(source->GetDisplayId()))
+                gender = creatureDisplay->Gender;
+            if (gender == GENDER_NONE)
+                gender = source->getGender();
+
+            if (uint32 broadcastTextSoundId = bct->SoundEntriesID[gender == GENDER_MALE ? 0 : 1])
+                finalSound = broadcastTextSoundId;
+        }
+
+        return finalSound;
     }();
 
     if (fSound)


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes sound selection logic so `creature_text.sound` is only overridden by `broadcast_text.SoundEntriesID*` when it's non-zero; `creature_text.sound` will still be used when `broadcast_text` has no sound data.

**Issues addressed:**

none

**Tests performed:**

tested in-game

**Known issues and TODO list:**

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
