### PR TITLE
Core/Movement: stuck in teleportation limbo fix

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -2050,15 +2050,7 @@ bool Player::TeleportTo(uint32 mapid, float x, float y, float z, float orientati
     if (!InBattleground() && mEntry->IsBattlegroundOrArena())
         return false;
 
-    SetGlobalTeleport(true);
-    AddDelayedEvent(100, [this, mapid, x, y, z, orientation, options, spellID]() -> void
-    {
-        if (!IsHasGlobalTeleport())
-            return;
-
-        SetGlobalTeleport(false);
-        SafeTeleport(mapid, x, y, z, orientation, options, spellID);
-    });
+    SafeTeleport(mapid, x, y, z, orientation, options, spellID);
 
     return true;
 }


### PR DESCRIPTION
* fixed all kinds of stucks inside zones/dungeons/LFG/etc.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
* If you enter/exit the same dungeon a few times, you could end up completely jailed inside. Nothing will let you out, not even relogging or restarting.
* this fix will allow you to teleport out of zones/dungeons/LFG

**Issues addressed:**

could help with [issue #169](https://github.com/The-Legion-Preservation-Project/LegionCore-7.3.5/issues/169)


**Tests performed:**

tested in-game


**Known issues and TODO list:** (add/remove lines as needed)

- `SetGlobalTeleport` and `IsHasGlobalTeleport` should probably be removed, as there are no such methods in TrinityCore.


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
