### PR TITLE
Core/Scripts: Quest 26290 Secrets of the Tower

### DIFF
--- a/sql/updates/world/2024_11_30_quest_26290.sql
+++ b/sql/updates/world/2024_11_30_quest_26290.sql
@@ -1,0 +1,20 @@
+--
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (79522, 79523);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(79522, 'spell_westfall_sniper_fire_proc'),
+(79523, 'spell_westfall_sniper_fire');
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 7024;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `comment`) VALUES
+(7024, 0, 0, 'I\'ve got your back, $n.', 15, 0, 100, 0, 0, 0, 42531, 'Agent Kearnen to Player'),
+(7024, 0, 1, 'Headshot!', 15, 0, 100, 0, 0, 0, 42532, 'Agent Kearnen to Player'),
+(7024, 0, 2, 'Not a chance.', 15, 0, 100, 0, 0, 0, 42533, 'Agent Kearnen to Player'),
+(7024, 0, 3, 'Easy peasy.', 15, 0, 100, 0, 0, 0, 42534, 'Agent Kearnen to Player'),
+(7024, 0, 4, 'Got him!', 15, 0, 100, 0, 0, 0, 42535, 'Agent Kearnen to Player');
+
+DELETE FROM `spell_area` WHERE `area` = 40 AND `spell` = 79522;
+INSERT INTO `spell_area` (`area`, `spell`, `quest_start`, `quest_start_status`, `quest_end`, `quest_end_status`, `autocast`, `aura_spell`, `racemask`, `gender`) VALUES
+(40, 79522, 26290, 10, 0, 11, 1, 0, 0, 2);
+
+-- disable xp for mercenary
+UPDATE `creature_template` SET `flags_extra` = 0x40 WHERE `entry` = 42656;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -17866,6 +17866,10 @@ void Unit::ProcDamageAndSpellFor(bool isVictim, Unit* target, uint32 procFlag, u
         if (!sConditionMgr->IsObjectMeetToConditions(condInfo, conditions))
             continue;
 
+        // AuraScript Hook
+        if (!triggerData.aura->CallScriptCheckProcHandlers(itr->second.get(), eventInfo))
+            continue;
+
         // Triggered spells not triggering additional spells
         bool triggered = !(spellProto->HasAttribute(SPELL_ATTR3_CAN_PROC_WITH_TRIGGERED)) ? (procExtra & PROC_EX_INTERNAL_TRIGGERED && !(procFlag & PROC_FLAG_DONE_TRAP_ACTIVATION)) : false;
 

--- a/src/server/game/Spells/Auras/SpellAuras.h
+++ b/src/server/game/Spells/Auras/SpellAuras.h
@@ -285,6 +285,7 @@ class Aura
         void CallScriptEffectManaShieldHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, float & absorbAmount, bool & defaultPrevented);
         void CallScriptEffectAfterManaShieldHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, float & absorbAmount);
         void CallScriptEffectSplitDamageHandlers(AuraEffect* aurEff, AuraApplication const* aurApp, DamageInfo & dmgInfo, float & absorbAmount);
+        bool CallScriptCheckProcHandlers(AuraApplication const* aurApp, ProcEventInfo& eventInfo);
         void SetScriptData(uint32 type, uint32 data);
         void SetScriptGuid(uint32 type, ObjectGuid const& data);
         // Spell Proc Hooks

--- a/src/server/game/Spells/SpellScript.cpp
+++ b/src/server/game/Spells/SpellScript.cpp
@@ -1092,6 +1092,16 @@ void AuraScript::EffectManaShieldHandler::Call(AuraScript* auraScript, AuraEffec
     (auraScript->*pEffectHandlerScript)(aurEff, dmgInfo, absorbAmount);
 }
 
+AuraScript::CheckProcHandler::CheckProcHandler(AuraCheckProcFnType handlerScript)
+{
+    _HandlerScript = handlerScript;
+}
+
+bool AuraScript::CheckProcHandler::Call(AuraScript* auraScript, ProcEventInfo& eventInfo)
+{
+    return (auraScript->*_HandlerScript)(eventInfo);
+}
+
 AuraScript::EffectProcHandler::EffectProcHandler(AuraEffectProcFnType effectHandlerScript, uint8 effIndex, uint16 effName) : EffectBase(effIndex, effName)
 {
     _EffectHandlerScript = effectHandlerScript;

--- a/src/server/game/Spells/SpellScript.h
+++ b/src/server/game/Spells/SpellScript.h
@@ -673,6 +673,14 @@ class AuraScript : public _SpellScript
             private:
                 AuraEffectAbsorbFnType pEffectHandlerScript;
         };
+        class CheckProcHandler
+        {
+            public:
+                CheckProcHandler(AuraCheckProcFnType handlerScript);
+                bool Call(AuraScript* auraScript, ProcEventInfo& eventInfo);
+            private:
+                AuraCheckProcFnType _HandlerScript;
+        };
         class EffectProcHandler : public EffectBase
         {
             public:
@@ -698,6 +706,7 @@ class AuraScript : public _SpellScript
         class EffectApplyHandlerFunction : public AuraScript::EffectApplyHandler { public: EffectApplyHandlerFunction(AuraEffectApplicationModeFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName, AuraEffectHandleModes _mode) : AuraScript::EffectApplyHandler((AuraScript::AuraEffectApplicationModeFnType)_pEffectHandlerScript, _effIndex, _effName, _mode) {} }; \
         class EffectAbsorbFunction : public AuraScript::EffectAbsorbHandler { public: EffectAbsorbFunction(AuraEffectAbsorbFnType _pEffectHandlerScript, uint8 _effIndex, uint16 _effName) : AuraScript::EffectAbsorbHandler((AuraScript::AuraEffectAbsorbFnType)_pEffectHandlerScript, _effIndex, _effName) {} }; \
         class EffectManaShieldFunction : public AuraScript::EffectManaShieldHandler { public: EffectManaShieldFunction(AuraEffectAbsorbFnType _pEffectHandlerScript, uint8 _effIndex) : AuraScript::EffectManaShieldHandler((AuraScript::AuraEffectAbsorbFnType)_pEffectHandlerScript, _effIndex) {} }; \
+        class CheckProcHandlerFunction : public AuraScript::CheckProcHandler { public: CheckProcHandlerFunction(AuraCheckProcFnType handlerScript) : AuraScript::CheckProcHandler((AuraScript::AuraCheckProcFnType)handlerScript) {} }; \
         class EffectProcHandlerFunction : public AuraScript::EffectProcHandler { public: EffectProcHandlerFunction(AuraEffectProcFnType effectHandlerScript, uint8 effIndex, uint16 effName) : AuraScript::EffectProcHandler((AuraScript::AuraEffectProcFnType)effectHandlerScript, effIndex, effName) {} }; \
 
         #define PrepareAuraScript(CLASSNAME) AURASCRIPT_FUNCTION_TYPE_DEFINES(CLASSNAME) AURASCRIPT_FUNCTION_CAST_DEFINES(CLASSNAME)
@@ -851,6 +860,12 @@ class AuraScript : public _SpellScript
 
         // example: OnEffectSplitDamage += AuraEffectAbsorbFn(class::function, EffectIndexSpecifier);
         HookList<EffectAbsorbHandler> OnEffectSplitDamage;
+
+        // executed when aura checks if it can proc
+        // example: DoCheckProc += AuraCheckProcFn(class::function);
+        // where function is: bool function (ProcEventInfo& eventInfo);
+        HookList<CheckProcHandler> DoCheckProc;
+        #define AuraCheckProcFn(F) CheckProcHandlerFunction(&F)
 
         // executed when aura effect procs
         // example: OnEffectProc += AuraEffectProcFn(class::function, EffectIndexSpecifier, EffectAuraNameSpecifier);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Adds `DoCheckProc` support to spell scripts
  - Ref: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/89490e4d7f4abff0eb756fcf07fbf21d7ca6381b
- Adds scripts to support sniper fire on [Secrets Of The Tower](https://www.wowhead.com/quest=26290)
  - Ref: https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/9abea087e5152a5eb5ba52ad3251a7c55931b3ac
- Disables XP for killing [Mercenary](https://www.wowhead.com/npc=42656)

**Issues addressed:**

Closes #191 

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
