### PR TITLE
Core/Scripts: Fixes for quest 26297 

### DIFF
--- a/sql/updates/world/2024_12_01_areatrigger_debug_strings.sql
+++ b/sql/updates/world/2024_12_01_areatrigger_debug_strings.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM `trinity_string` WHERE `entry` IN (1204, 1265);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES
+(1204, 'You have entered areatrigger %u.'),
+(1265, 'You have left areatrigger %u.');

--- a/sql/updates/world/2024_12_01_quest_26297.sql
+++ b/sql/updates/world/2024_12_01_quest_26297.sql
@@ -1,0 +1,37 @@
+-- don't summon shadowy figure on quest accept (with timed action)
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 42425 AND `source_type` = 0 AND `event_type` = 19;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4242500 AND `source_type` = 9;
+UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` = 42425;
+
+-- don't use condition or smart script for areatrigger (now using c++ script)
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 22 AND `SourceEntry` = 5998;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 5998 AND `source_type` = 2;
+
+DELETE FROM `areatrigger_scripts` WHERE `entry` = 5998;
+INSERT INTO `areatrigger_scripts` (`entry`, `ScriptName`)
+VALUES (5998, 'areatrigger_westfall_dawning_of_a_new_day');
+
+-- raid boss whisper warning
+UPDATE `creature_text` SET `Type` = 42, `Sound` = 37666 WHERE `CreatureID` = 42680 AND BroadcastTextID = 42569;
+
+-- tweaked from existing; no delay on first text, end with cheer sound
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4268000;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `Difficulties`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(4268000, 9, 0, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 1, 8, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 1, 0, '', 0, 0, 100, 0, 3000, 3000, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 2, 0, '', 0, 0, 100, 0, 4000, 4000, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 3, 0, '', 0, 0, 100, 0, 8000, 8000, 0, 0, 1, 2, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 4, 0, '', 0, 0, 100, 0, 6000, 6000, 0, 0, 1, 3, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 5, 0, '', 0, 0, 100, 0, 6000, 6000, 0, 0, 1, 4, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 6, 0, '', 0, 0, 100, 0, 10000, 10000, 0, 0, 1, 5, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 7, 0, '', 0, 0, 100, 0, 7000, 7000, 0, 0, 1, 6, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 8, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 5, 25, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - emote'),
+(4268000, 9, 9, 0, '', 0, 0, 100, 0, 10000, 10000, 0, 0, 1, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - text'),
+(4268000, 9, 10, 0, '', 0, 0, 100, 0, 2000, 2000, 0, 0, 33, 42680, 0, 0, 0, 0, 0, 18, 30, 0, 0, 0, 0, 0, 0, 'Shadowy Figure - killcredit'),
+(4268000, 9, 11, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 11, 42390, 25, 0, 0, 0, 0, 0, 'data'),
+(4268000, 9, 12, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 11, 42386, 25, 0, 0, 0, 0, 0, 'data'),
+(4268000, 9, 13, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 11, 42391, 25, 0, 0, 0, 0, 0, 'data'),
+(4268000, 9, 14, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 45, 1, 1, 0, 0, 0, 0, 11, 42383, 25, 0, 0, 0, 0, 0, 'data'),
+(4268000, 9, 15, 0, '', 0, 0, 100, 0, 0, 0, 0, 0, 4, 13840, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'cheer'),
+(4268000, 9, 16, 0, '', 0, 0, 100, 0, 10000, 10000, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'despawn');

--- a/src/server/game/Handlers/MiscHandler.cpp
+++ b/src/server/game/Handlers/MiscHandler.cpp
@@ -210,7 +210,7 @@ void WorldSession::HandleAreaTrigger(WorldPackets::Misc::AreaTrigger& packet)
     }
 
     if (player->isDebugAreaTriggers)
-        ChatHandler(player).PSendSysMessage(LANG_DEBUG_AREATRIGGER_REACHED, packet.AreaTriggerID);
+        ChatHandler(player).PSendSysMessage(packet.Entered ? LANG_DEBUG_AREATRIGGER_ENTERED : LANG_DEBUG_AREATRIGGER_LEFT, packet.AreaTriggerID);
 
     // set for future scrip using.
     player->SetLastAreaTrigger(atEntry);

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -765,8 +765,10 @@ enum TrinityStrings
     LANG_MOVIE_NOT_EXIST                = 1201,
     LANG_DEBUG_AREATRIGGER_ON           = 1202,
     LANG_DEBUG_AREATRIGGER_OFF          = 1203,
-    LANG_DEBUG_AREATRIGGER_REACHED      = 1204,
-    // Room for more debug                1205-1299 not used
+    LANG_DEBUG_AREATRIGGER_ENTERED      = 1204,
+    // 1205-1264 are (incorrectly) used for some BG?
+    LANG_DEBUG_AREATRIGGER_LEFT         = 1265,
+    // Room for more debug                1266-1299 not used
 
     // AV
     LANG_BG_AV_ALLY                     = 1300,

--- a/src/server/scripts/EasternKingdoms/zone_westfall.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_westfall.cpp
@@ -35,12 +35,18 @@ EndContentData */
 enum WestfallCreature
 {
     NPC_MERCENARY                     = 42656,
-    NPC_AGENT_KEARNEN                 = 7024
+    NPC_AGENT_KEARNEN                 = 7024,
+    NPC_SHADOWY_FIGURE                = 42680
 };
 
 enum WestfallSpell
 {
-    SPELL_KILL_SHOT_TRIGGERED        = 79525
+    SPELL_KILL_SHOT_TRIGGERED         = 79525
+};
+
+enum WestfallQuest
+{
+    QUEST_THE_DAWNING_OF_A_NEW_DAY    = 26297
 };
 
 /*######
@@ -535,6 +541,24 @@ class spell_westfall_sniper_fire : public SpellScript
     }
 };
 
+class areatrigger_westfall_dawning_of_a_new_day : public AreaTriggerScript
+{
+public:
+    areatrigger_westfall_dawning_of_a_new_day()
+      : AreaTriggerScript("areatrigger_westfall_dawning_of_a_new_day")
+    {
+    }
+
+    bool OnTrigger(Player* player, AreaTriggerEntry const* /*trigger*/, bool enter) override
+    {
+        if (enter && player->GetQuestStatus(QUEST_THE_DAWNING_OF_A_NEW_DAY) == QuestStatus::QUEST_STATUS_INCOMPLETE)
+            if (!player->FindNearestCreature(NPC_SHADOWY_FIGURE, 20))
+                player->SummonCreature(NPC_SHADOWY_FIGURE, -11016.6, 1479.32, 47.736, 2.478, TEMPSUMMON_MANUAL_DESPAWN);
+
+        return false;
+    }
+};
+
 void AddSC_westfall()
 {
     new npc_daphne_stilwell();
@@ -546,4 +570,5 @@ void AddSC_westfall()
     RegisterSpellScript(spell_westfall_wake_harvest_golem);
     RegisterAuraScript(spell_westfall_sniper_fire_proc);
     RegisterSpellScript(spell_westfall_sniper_fire);
+    new areatrigger_westfall_dawning_of_a_new_day();
 }


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix `.debug areatrigger` to show distinct enter/leave messages
- Add AreaTriggerScript to start event for quest [The Dawning Of A New Day](https://www.wowhead.com/quest=26297)
- Adjust event timing
- Play sounds at start and end of event

**Issues addressed:**

Closes #193 

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
