### PR TITLE
Core/Loot: fix crash caused by currency loot

### DIFF
--- a/src/server/game/Loot/LootMgr.cpp
+++ b/src/server/game/Loot/LootMgr.cpp
@@ -3300,7 +3300,7 @@ bool LootTemplate::HasQuestDropForPlayer(LootTemplateMap const& store, Player co
             if (Referenced->second->HasQuestDropForPlayer(store, player, i->groupid))
                 return true;
         }
-        else if (player->HasQuestForItem(i->itemid))
+        else if (i->itemid > 0 && player->HasQuestForItem(i->itemid))
             return true;                                    // active quest drop found
     }
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix a crash caused by encountering certain lootable objects in the world.

**Issues addressed:**

LegionCore has a custom loot system where loot items may be currency and have no item id. This caused `LootTemplate::HasQuestDropForPlayer` to crash when encountering objects like [Suspiciously Glowing Chest](https://www.wowhead.com/object=243796).

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
