### PR TITLE
Core/Creatures: fix power type display regression

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2267,42 +2267,12 @@ bool Creature::LoadCreatureFromDB(ObjectGuid::LowType guid, Map* map, bool addTo
                 curhealth = 1;
         }
 
-        switch (getClass())
-        {
-            case CLASS_WARRIOR:
-                SetPowerType(POWER_RAGE);
-                //SetMaxPower(POWER_RAGE, GetCreatePowers(POWER_RAGE));
-                //SetPower(POWER_RAGE, GetCreatePowers(POWER_RAGE));
-                break;
-            case CLASS_ROGUE:
-                SetPowerType(POWER_ENERGY);
-                SetMaxPower(POWER_ENERGY, GetCreatePowers(POWER_ENERGY));
-                SetPower(POWER_ENERGY, GetCreatePowers(POWER_ENERGY));
-                break;
-            default:
-                SetPower(POWER_MANA, data->curmana);
-                break;
-        }
+        SetPower(POWER_MANA, data->curmana);
     }
     else
     {
         curhealth = GetMaxHealth();
-        switch (getClass())
-        {
-            case CLASS_WARRIOR:
-                SetPowerType(POWER_RAGE);
-                //SetMaxPower(POWER_RAGE, GetCreatePowers(POWER_RAGE));
-                //SetPower(POWER_RAGE, GetCreatePowers(POWER_RAGE));
-                break;
-            case CLASS_ROGUE:
-                SetPowerType(POWER_ENERGY);
-                SetMaxPower(POWER_ENERGY, GetCreatePowers(POWER_ENERGY));
-                SetPower(POWER_ENERGY, GetCreatePowers(POWER_ENERGY));
-                break;
-            default:
-                SetFullPower(POWER_MANA);
-                break;
-        }
+        SetFullPower(POWER_MANA);
     }
 
     SetHealth(m_deathState == ALIVE ? curhealth : 0);

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -11167,6 +11167,7 @@ void Unit::SetPowerType(Powers power)
             break;
         case POWER_RAGE: // Reset to zero
             SetPower(POWER_RAGE, 0);
+            break;
         case POWER_FOCUS: // Make it full
             SetFullPower(new_powertype);
             break;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fix power type display regression caused by #174 
- Code now matches AshamaneCore

**Issues addressed:**

Incorrect power display (100 rage) after #174 

![kaliri](https://github.com/user-attachments/assets/43549211-ce83-49cf-8d9e-963da4a11f4c)

Correct power display (no power display) with this PR:

![kaliri-fixed](https://github.com/user-attachments/assets/bddb04c2-5d37-429e-947e-492d9a25aadf)

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
