### PR TITLE
Core/Quests: show quest discovery popup when looting items that start quests

### DIFF
--- a/src/server/game/Entities/Creature/GossipDef.cpp
+++ b/src/server/game/Entities/Creature/GossipDef.cpp
@@ -497,7 +497,7 @@ void PlayerMenu::SendQuestGiverStatus(QuestGiverStatus questStatus, ObjectGuid n
         player->SendDirectMessage(packet.Write());
 }
 
-void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGUID, bool autoLaunched, bool displayPopup, bool isAreaTrigger /*=false*/) const
+void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGUID, bool autoLaunched, bool displayPopup, bool isAreaTrigger /*=false*/, uint32 questStartItemId /*= 0*/) const
 {
     Player* player = _session->GetPlayer();
     if (!player)
@@ -547,7 +547,7 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGU
     if (quest->SourceSpellID)
         packet.LearnSpells.push_back(quest->SourceSpellID);
 
-    packet.QuestStartItemID = 0;
+    packet.QuestStartItemID = questStartItemId;
 
     quest->BuildQuestRewards(packet.Rewards, player);
 

--- a/src/server/game/Entities/Creature/GossipDef.h
+++ b/src/server/game/Entities/Creature/GossipDef.h
@@ -219,7 +219,7 @@ public:
     void SendQuestGiverStatus(QuestGiverStatus questStatus, ObjectGuid npcGUID) const;
     void SendQuestGiverQuestList(uint32 BroadcastTextID, ObjectGuid npcGUID);
     void SendQuestQueryResponse(uint32 questId) const;
-    void SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGUID, bool autoLaunched, bool displayPopup, bool isArea = false) const;
+    void SendQuestGiverQuestDetails(Quest const* quest, ObjectGuid npcGUID, bool autoLaunched, bool displayPopup, bool isArea = false, uint32 questStartItemId = 0) const;
     void SendQuestGiverOfferReward(Quest const* quest, ObjectGuid npcGUID, bool autoLaunched) const;
     void SendQuestGiverRequestItems(Quest const* quest, ObjectGuid npcGUID, bool canComplete, bool autoLaunched) const;
 };

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -17881,6 +17881,14 @@ void Player::SendNewItem(Item* item, uint32 count, bool received, bool created, 
         CastSpell(this, 218892);
     if (item->GetEntry() == 136802)
         UpdateAchievementCriteria(CRITERIA_TYPE_SCRIPT_EVENT_2, 54824);
+
+    uint32 startQuestId = item->GetTemplate()->GetStartQuestID();
+    Quest const* quest = startQuestId ? sQuestDataStore->GetQuestTemplate(startQuestId) : nullptr;
+    if (quest /*&& quest->IsAutoAccept()*/ && CanAddQuest(quest, false) && CanTakeQuest(quest, false))
+    {
+        AddQuestAndCheckCompletion(quest, item);
+        PlayerTalkClass->SendQuestGiverQuestDetails(quest, GetGUID(), true, true, false, item->GetEntry());
+    }
 }
 
 /*********************************************************/


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Shows quest discovered popup when looting items that start quests

**Issues addressed:**

Closes #207
Closes #192 

**Tests performed:**

tested in-game with a couple items:
- [Tainted Arcane Sliver](https://www.wowhead.com/item=20483)
- [Dirt Stained Scroll](https://www.wowhead.com/item=58898)

**Known issues and TODO list:**

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
