### PR TITLE
Core/Packets: CMSG_QUEST_GIVER_CLOSE_QUEST implemented

### DIFF
--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -703,6 +703,18 @@ void WorldSession::HandleQuestgiverCompleteQuest(WorldPackets::Quest::QuestGiver
     }
 }
 
+void WorldSession::HandleQuestgiverCloseQuest(WorldPackets::Quest::QuestGiverCloseQuest& questGiverCloseQuest)
+{
+    if (_player->FindQuestSlot(questGiverCloseQuest.QuestID) >= MAX_QUEST_LOG_SIZE)
+        return;
+
+    Quest const* quest = sQuestDataStore->GetQuestTemplate(questGiverCloseQuest.QuestID);
+    if (!quest)
+        return;
+
+    //sScriptMgr->OnQuestAcknowledgeAutoAccept(_player, quest); // @TODO : QuestScript
+}
+
 void WorldSession::HandlePushQuestToParty(WorldPackets::Quest::PushQuestToParty& packet)
 {
     if (_player->GetQuestStatus(packet.QuestID) == QUEST_STATUS_NONE || _player->GetQuestStatus(packet.QuestID) == QUEST_STATUS_REWARDED)

--- a/src/server/game/Server/Packets/QuestPackets.cpp
+++ b/src/server/game/Server/Packets/QuestPackets.cpp
@@ -363,6 +363,11 @@ void WorldPackets::Quest::QuestGiverCompleteQuest::Read()
     FromScript = _worldPacket.ReadBit();
 }
 
+void WorldPackets::Quest::QuestGiverCloseQuest::Read()
+{
+    _worldPacket >> QuestID;
+}
+
 WorldPacket const* WorldPackets::Quest::QuestGiverQuestDetails::Write()
 {
     _worldPacket << QuestGiverGUID;

--- a/src/server/game/Server/Packets/QuestPackets.h
+++ b/src/server/game/Server/Packets/QuestPackets.h
@@ -351,6 +351,16 @@ namespace WorldPackets
             bool FromScript = false;
         };
 
+        class QuestGiverCloseQuest final : public ClientPacket
+        {
+        public:
+            QuestGiverCloseQuest(WorldPacket&& packet) : ClientPacket(CMSG_QUEST_GIVER_CLOSE_QUEST, std::move(packet)) { }
+
+            void Read() override;
+
+            int32 QuestID = 0;
+        };
+
         struct QuestObjectiveSimple
         {
             int32 ID = 0;

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -730,6 +730,7 @@ void OpcodeTable::Initialize()
     DEFINE_HANDLER(CMSG_QUEST_CONFIRM_ACCEPT,                               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestConfirmAccept);
     DEFINE_HANDLER(CMSG_QUEST_GIVER_ACCEPT_QUEST,                           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestGiverAcceptQuest);
     DEFINE_HANDLER(CMSG_QUEST_GIVER_CHOOSE_REWARD,                          STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestGiverChooseReward);
+    DEFINE_HANDLER(CMSG_QUEST_GIVER_CLOSE_QUEST,                            STATUS_LOGGEDIN,  PROCESS_INPLACE,      &WorldSession::HandleQuestgiverCloseQuest);
     DEFINE_HANDLER(CMSG_QUEST_GIVER_COMPLETE_QUEST,                         STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestgiverCompleteQuest);
     DEFINE_HANDLER(CMSG_QUEST_GIVER_HELLO,                                  STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestGiverHello);
     DEFINE_HANDLER(CMSG_QUEST_GIVER_QUERY_QUEST,                            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestGiverQueryQuest);

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -577,6 +577,7 @@ enum OpcodeClient : uint16
     CMSG_QUEST_CONFIRM_ACCEPT                               = 0x34A1,
     CMSG_QUEST_GIVER_ACCEPT_QUEST                           = 0x349B,
     CMSG_QUEST_GIVER_CHOOSE_REWARD                          = 0x349D,
+    CMSG_QUEST_GIVER_CLOSE_QUEST                            = 0x354D,
     CMSG_QUEST_GIVER_COMPLETE_QUEST                         = 0x349C,
     CMSG_QUEST_GIVER_HELLO                                  = 0x3499,
     CMSG_QUEST_GIVER_QUERY_QUEST                            = 0x349A,

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -454,6 +454,7 @@ namespace WorldPackets
         class QueryTreasurePicker;
         class QuestGiverChooseReward;
         class QuestGiverCompleteQuest;
+        class QuestGiverCloseQuest;
         class QuestGiverRequestReward;
         class QuestGiverQueryQuest;
         class QuestPushResult;
@@ -1595,6 +1596,7 @@ class WorldSession
         void HandleQuestLogRemoveQuest(WorldPackets::Quest::QuestLogRemoveQuest& packet);
         void HandleQuestConfirmAccept(WorldPackets::Quest::QuestConfirmAccept& packet);
         void HandleQuestgiverCompleteQuest(WorldPackets::Quest::QuestGiverCompleteQuest& packet);
+        void HandleQuestgiverCloseQuest(WorldPackets::Quest::QuestGiverCloseQuest& questGiverCloseQuest);
         void HandlePushQuestToParty(WorldPackets::Quest::PushQuestToParty& packet);
         void HandleQuestPushResult(WorldPackets::Quest::QuestPushResult& packet);
         void HandleRequestWorldQuestUpdate(WorldPackets::Quest::RequestWorldQuestUpdate& packet);


### PR DESCRIPTION
* unknown packet 0x354D identified

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

This packet is triggered when completing a quest and accepting the next one "on the go". For example:

* Completing [Canyon Romp](https://www.wowhead.com/quest=26514/canyon-romp) and accepting [They've Wised Up](https://www.wowhead.com/quest=26544/theyve-wised-up) triggers this packet.

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- requires a port of the [QuestScript](https://github.com/TrinityCore/TrinityCore/blob/1fb4acc25ae89360e71d33a8f7cba99bcc028b32/src/server/game/Scripting/ScriptMgr.h#L950)(`ScriptMgr`) from TC


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
