### PR TITLE
Core/Scripts: Quest 26520 Saving Foreman Oslow

### DIFF
--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -1,0 +1,220 @@
+--
+DELETE FROM `creature_template_addon` WHERE `entry` IN (341,382,43194,43196);
+DELETE FROM `creature_template_addon` WHERE `entry` BETWEEN 648 AND 653;
+INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES
+(341,0,0,65543,1,0,'80694'),
+(382,0,0,65536,1,0, '80699'),
+(648,0,0,65536,1,0,'80698'),
+(649,0,0,65536,1,0,'80698'),
+(650,0,0,65536,1,0,'80698'),
+(651,0,0,65536,1,0,'80698'),
+(652,0,0,65536,1,0,'80698'),
+(653,0,0,65536,1,0,'80698'),
+(43194,0,0,65536,1,0, '80699'),
+(43196,0,0,65536,1,0,'80694');
+
+-- bridge workers animation
+UPDATE `creature` SET `AiID` = 726 WHERE `id` BETWEEN 648 AND 653;
+
+-- Detect Quest Invis Zone 1
+DELETE FROM `spell_area` WHERE `spell` IN (80695) AND `area` = 44;
+INSERT INTO `spell_area` (`spell`,`area`,`quest_start`,`quest_end`,`aura_spell`,`racemask`,`gender`,`autocast`,`quest_start_status`,`quest_end_status`) VALUES
+(80695,44,0,26520,0,18875469,2,1,0,11); -- Zone Wide
+
+-- Detect Quest Invis Zone 2
+DELETE FROM `spell_area` WHERE `spell` IN (80696) AND `area` = 44;
+INSERT INTO `spell_area` (`spell`,`area`,`quest_start`,`quest_end`,`aura_spell`,`racemask`,`gender`,`autocast`,`quest_start_status`,`quest_end_status`) VALUES
+(80696,44,26520,0,0,18875469,2,1,64,0); -- Zone Wide
+
+-- marshall marris should be sitting and drinking
+SET @ENTRY := 382;
+UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=@ENTRY;
+UPDATE `creature_template_addon` SET `bytes1` = 65541 WHERE `entry` = @ENTRY;
+DELETE FROM `smart_scripts` WHERE `entryorguid`=-38726 AND `source_type`=0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(-38726,0,0,0,1,0,100,0,8000,8000,8000,8000,11,58952,0,0,0,0,0,1,0,0,0,0,0,0,0,'Marshal Marris - OOC - Cast ''Drink Alcohol''');
+
+-- Pathing for Guard Ashlock Entry: 932
+SET @NPC := 38725;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-9281.391,`position_y`=-2286.225,`position_z`=67.7533 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,257,0, '5301');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-9281.391,-2286.225,67.7533,0,0,0,0,100,0),
+(@PATH,2,-9326.391,-2282.725,71.5033,0,0,0,0,100,0),
+(@PATH,3,-9365.141,-2279.975,71.5033,0,0,0,0,100,0),
+(@PATH,4,-9401.141,-2268.725,68.0033,0,0,0,0,100,0),
+(@PATH,5,-9406.141,-2265.225,67.7533,0,0,0,0,100,0),
+(@PATH,6,-9411.66,-2264.84,67.44,0,120000,0,0,100,0),
+(@PATH,7,-9412.391,-2266.225,67.5033,0,0,0,0,100,0),
+(@PATH,8,-9412.891,-2274.725,67.7533,0,0,0,0,100,0),
+(@PATH,9,-9364.891,-2279.725,71.5033,0,0,0,0,100,0),
+(@PATH,10,-9330.391,-2282.725,71.7533,0,0,0,0,100,0),
+(@PATH,11,-9291.391,-2285.975,67.7533,0,0,0,0,100,0),
+(@PATH,12,-9282.12,-2287.61,67.5666,0,120000,0,0,100,0);
+
+-- Pathing for Guard Clarke Entry: 934
+SET @NPC := 38634;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-9344.355,`position_y`=-2206.349,`position_z`=61.89775 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,257,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-9344.355,-2206.349,61.89775,0,0,0,0,100,0),
+(@PATH,2,-9335.028,-2207.953,61.89775,0,0,0,0,100,0),
+(@PATH,3,-9322.396,-2210.031,61.89775,0,0,0,0,100,0),
+(@PATH,4,-9311.435,-2210.67,61.89775,0,0,0,0,100,0),
+(@PATH,5,-9297.224,-2212.776,61.89775,0,0,0,0,100,0),
+(@PATH,6,-9285.208,-2216.076,63.25996,0,0,0,0,100,0),
+(@PATH,7,-9284.114,-2226.769,63.39107,0,0,0,0,100,0),
+(@PATH,8,-9283.647,-2243.695,63.57106,0,0,0,0,100,0),
+(@PATH,9,-9281.135,-2260.52,65.97218,0,0,0,0,100,0),
+(@PATH,10,-9275.419,-2273.584,67.4109,0,0,0,0,100,0),
+(@PATH,11,-9271.06,-2266.026,66.2466,0,0,0,0,100,0),
+(@PATH,12,-9270.646,-2245.761,64.04616,0,0,0,0,100,0),
+(@PATH,13,-9269.661,-2222.433,64.04756,0,0,0,0,100,0),
+(@PATH,14,-9268.26,-2200.005,64.05788,0,0,0,0,100,0),
+(@PATH,15,-9266.45,-2182.234,64.08961,0,0,0,0,100,0),
+(@PATH,16,-9268.26,-2200.005,64.05788,0,0,0,0,100,0),
+(@PATH,17,-9269.661,-2222.433,64.04756,0,0,0,0,100,0),
+(@PATH,18,-9270.646,-2245.761,64.04616,0,0,0,0,100,0),
+(@PATH,19,-9271.06,-2266.026,66.2466,0,0,0,0,100,0),
+(@PATH,20,-9275.419,-2273.584,67.4109,0,0,0,0,100,0),
+(@PATH,21,-9281.135,-2260.52,65.97218,0,0,0,0,100,0),
+(@PATH,22,-9283.647,-2243.695,63.57106,0,0,0,0,100,0),
+(@PATH,23,-9284.114,-2226.769,63.39107,0,0,0,0,100,0),
+(@PATH,24,-9285.208,-2216.076,63.25996,0,0,0,0,100,0),
+(@PATH,25,-9296.33,-2212.813,61.89775,0,0,0,0,100,0),
+(@PATH,26,-9311.435,-2210.67,61.89775,0,0,0,0,100,0),
+(@PATH,27,-9322.396,-2210.031,61.89775,0,0,0,0,100,0),
+(@PATH,28,-9335.001,-2207.957,61.89775,0,0,0,0,100,0);
+
+-- Pathing for Guard Adams Entry: 936
+SET @NPC := 38537;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-9212.636,`position_y`=-2174.064,`position_z`=64.05842 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,257,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-9212.636,-2174.064,64.05842,0,0,0,0,100,0),
+(@PATH,2,-9245.297,-2171.292,63.93879,0,0,0,0,100,0),
+(@PATH,3,-9245.685,-2167.466,63.93879,0,30000,0,0,100,0),
+(@PATH,4,-9253.704,-2167.139,64.05788,0,0,0,0,100,0),
+(@PATH,5,-9254.052,-2135.928,63.93991,0,0,0,0,100,0),
+(@PATH,6,-9246.497,-2115.215,66.55289,0,0,0,0,100,0),
+(@PATH,7,-9243.474,-2098.984,72.62241,0,0,0,0,100,0),
+(@PATH,8,-9239.848,-2075.51,75.75473,0,0,0,0,100,0),
+(@PATH,9,-9234.389,-2072.974,76.53476,0,0,0,0,100,0),
+(@PATH,10,-9234.089,-2083.617,76.79282,0,0,0,0,100,0),
+(@PATH,11,-9220.588,-2089.068,81.41252,0,0,0,0,100,0),
+(@PATH,12,-9206.651,-2088.978,86.12273,0,0,0,0,100,0),
+(@PATH,13,-9189.044,-2094.362,87.86027,0,15000,0,0,100,0),
+(@PATH,14,-9235.082,-2087.048,76.55405,0,0,0,0,100,0),
+(@PATH,15,-9245.788,-2099.052,72.19589,0,0,0,0,100,0),
+(@PATH,16,-9246.594,-2118.702,65.59097,0,0,0,0,100,0),
+(@PATH,17,-9232.146,-2130.648,64.05843,0,0,0,0,100,0),
+(@PATH,18,-9212.241,-2135.419,64.05843,0,0,0,0,100,0),
+(@PATH,19,-9187.412,-2138.506,64.00642,0,0,0,0,100,0),
+(@PATH,20,-9187.227,-2160.702,64.05843,0,0,0,0,100,0);
+
+-- Pathing for Dorin Songblade Entry: 956
+SET @NPC := 38684;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-9247.676,`position_y`=-2240.278,`position_z`=64.05842 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-9247.676,-2240.278,64.05842,0,0,0,0,100,0),
+(@PATH,2,-9247.676,-2240.278,64.05842,2.583087,42000,0,0,100,0),
+(@PATH,3,-9250.197,-2244.496,64.05842,0,42000,0,0,100,0);
+
+-- remove duplicate ettins
+DELETE FROM `creature` WHERE `guid` IN (38740, 38849);
+
+-- Pathing for Canyon Ettin Entry: 43094
+SET @NPC := 38410;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-9105.46,`position_y`=-2208.16,`position_z`=126.5163 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-9105.46,-2208.16,126.5163,0,0,0,0,100,0),
+(@PATH,2,-9134.289,-2211.389,121.312,0,0,0,0,100,0),
+(@PATH,3,-9137.49,-2173.55,121.3245,0,0,0,0,100,0),
+(@PATH,4,-9127.85,-2137.67,123.4426,0,0,0,0,100,0),
+(@PATH,5,-9128.25,-2095.07,122.8061,0,0,0,0,100,0),
+(@PATH,6,-9103.65,-2086.67,127.4204,0,0,0,0,100,0),
+(@PATH,7,-9117.41,-2069.33,128.6535,0,0,0,0,100,0),
+(@PATH,8,-9111.11,-2064.42,128.7022,0,0,0,0,100,0),
+(@PATH,9,-9093.48,-2076.93,128.7146,0,0,0,0,100,0),
+(@PATH,10,-9070.16,-2087.55,129.0393,0,0,0,0,100,0),
+(@PATH,11,-9039.8,-2095.06,130.9568,0,0,0,0,100,0),
+(@PATH,12,-9015.53,-2091.76,132.5085,0,0,0,0,100,0),
+(@PATH,13,-9002.63,-2119.99,137.521,0,0,0,0,100,0),
+(@PATH,14,-9002.05,-2138.25,143.4562,0,0,0,0,100,0),
+(@PATH,15,-9001.05,-2160,133.3666,0,0,0,0,100,0),
+(@PATH,16,-9009.8,-2185.88,136.2239,0,0,0,0,100,0),
+(@PATH,17,-9041.53,-2193.89,131.472,0,0,0,0,100,0),
+(@PATH,18,-9068.82,-2174.21,132.5518,0,0,0,0,100,0),
+(@PATH,19,-9087,-2190.03,132.4278,0,0,0,0,100,0);
+
+-- Pathing for Canyon Ettin Entry: 43094
+SET @NPC := 38466;
+SET @PATH := @NPC * 10;
+UPDATE `creature` SET `spawndist`=0,`MovementType`=2,`position_x`=-8923.51,`position_y`=-2304.27,`position_z`=133.0706 WHERE `guid`=@NPC;
+DELETE FROM `creature_addon` WHERE `guid`=@NPC;
+INSERT INTO `creature_addon` (`guid`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES (@NPC,@PATH,0,0,1,0, '');
+DELETE FROM `waypoint_data` WHERE `id`=@PATH;
+INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`,`orientation`,`delay`,`move_type`,`action`,`action_chance`,`wpguid`) VALUES
+(@PATH,1,-8923.51,-2304.27,133.0706,0,0,0,0,100,0),
+(@PATH,2,-8931.27,-2331.67,132.8773,0,0,0,0,100,0),
+(@PATH,3,-8962.34,-2333.7,132.5694,0,0,0,0,100,0),
+(@PATH,4,-8982.57,-2351.04,132.5728,0,0,0,0,100,0),
+(@PATH,5,-9000.23,-2379.13,132.4703,0,0,0,0,100,0),
+(@PATH,6,-9017.43,-2401.64,130.3283,0,0,0,0,100,0),
+(@PATH,7,-9021.813,-2423.211,131.7126,0,0,0,0,100,0),
+(@PATH,8,-9050.23,-2437.75,128.3464,0,0,0,0,100,0),
+(@PATH,9,-9062.48,-2407.44,127.3151,0,0,0,0,100,0),
+(@PATH,10,-9094.87,-2388.64,124.0265,0,0,0,0,100,0),
+(@PATH,11,-9112.47,-2360.19,121.6273,0,0,0,0,100,0),
+(@PATH,12,-9111.24,-2354.57,122.5619,0,0,0,0,100,0),
+(@PATH,13,-9095.8,-2382.87,123.9354,0,0,0,0,100,0),
+(@PATH,14,-9061.45,-2399.56,128.0016,0,0,0,0,100,0),
+(@PATH,15,-9018.48,-2392.57,130.7203,0,0,0,0,100,0),
+(@PATH,16,-8992.11,-2368.29,132.5635,0,0,0,0,100,0),
+(@PATH,17,-8964.82,-2329.2,132.5481,0,0,0,0,100,0),
+(@PATH,18,-8956.58,-2292.35,132.5678,0,0,0,0,100,0),
+(@PATH,19,-8926.41,-2279.25,132.7044,0,0,0,0,100,0),
+(@PATH,20,-8905.42,-2245.47,133.3376,0,0,0,0,100,0),
+(@PATH,21,-8881.15,-2266.83,133.1034,0,0,0,0,100,0),
+(@PATH,22,-8895.5,-2281.12,133.7757,0,0,0,0,100,0),
+(@PATH,23,-8915.54,-2283.71,132.3846,0,0,0,0,100,0);
+
+-- Foreman Oslow text
+DELETE FROM `creature_text` WHERE `CreatureID`=341;
+INSERT INTO `creature_text` (`CreatureID`, `groupid`, `id`, `text`, `type`, `language`, `probability`, `emote`, `duration`, `sound`, `BroadcastTextId`, `comment`) VALUES
+(341, 0, 0, 'Somebody... please... get... rock... off... me...', 12, 0, 100, 0, 0, 0, 43173, 'Foreman Oslow'),
+(341, 0, 1, 'Hurts... Hurts so bad...', 12, 0, 100, 0, 0, 0, 43174, 'Foreman Oslow'),
+(341, 0, 2, 'Please... kill... me...', 12, 0, 100, 0, 0, 0, 43175, 'Foreman Oslow'),
+(341, 0, 3, 'I... just... wanted... to... build... the... damned... bridge...', 12, 0, 100, 0, 0, 0, 43176, 'Foreman Oslow');
+
+-- Bridge Worker Alex text
+DELETE FROM `creature_text` WHERE `CreatureID` IN (653,648,649,650,651,652);
+INSERT INTO `creature_text` (`CreatureID`, `groupid`, `id`, `text`, `type`, `language`, `probability`, `emote`, `duration`, `sound`, `BroadcastTextId`, `comment`) VALUES
+(653, 0, 0, 'PUT YOUR BACKS INTO IT, BOYS!', 12, 0, 100, 0, 0, 0, 43181, 'Bridge Worker Alex'),
+(653, 1, 0, 'HEAVE!', 12, 0, 100, 0, 0, 0, 43182, 'Bridge Worker Alex'),
+(653, 2, 0, 'DAMN ROCK WON''T BUDGE!', 12, 0, 100, 0, 0, 0, 43184, 'Bridge Worker Alex'),
+(653, 4, 0, 'PUSH HARDER!', 12, 0, 100, 0, 0, 0, 43185, 'Bridge Worker Alex'),
+(653, 3, 0, 'We''ll get you out of there, Foreman, just HANG ON!', 12, 0, 100, 0, 0, 0, 43187, 'Bridge Worker Alex'),
+(648, 0, 0, 'HO!', 12, 0, 100, 0, 0, 0, 43183, 'Bridge Worker Trent'),
+(649, 0, 0, 'HO!', 12, 0, 100, 0, 0, 0, 43183, 'Bridge Worker Dimitri'),
+(650, 0, 0, 'HO!', 12, 0, 100, 0, 0, 0, 43183, 'Bridge Worker Jess'),
+(651, 0, 0, 'HO!', 12, 0, 100, 0, 0, 0, 43183, 'Bridge Worker Daniel'),
+(652, 0, 0, 'HO!', 12, 0, 100, 0, 0, 0, 43183, 'Bridge Worker Matthew'),
+(652, 1, 0, 'I''M PUSHIN'' AS HARD AS I CAN! THING WEIGHS A TON!', 12, 0, 100, 0, 0, 0, 43186, 'Bridge Worker Matthew');

--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -38,6 +38,10 @@ UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_huge_boulder' WHERE 
 UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_subdued_ettin' WHERE `entry` = 43197;
 UPDATE `creature_template` SET `VehicleId` = 938 WHERE `entry` = 43197;
 
+-- clean out old data
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (341, 648, 649, 650, 651, 652, 653, 43196, 43197) AND `source_type` = 0;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 4319600 AND `source_type` = 9;
+
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 43094;
 DELETE FROM `smart_scripts` WHERE `entryorguid` = 43094 AND `source_type` = 0;
 INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES

--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -26,6 +26,33 @@ DELETE FROM `spell_area` WHERE `spell` IN (80696) AND `area` = 44;
 INSERT INTO `spell_area` (`spell`,`area`,`quest_start`,`quest_end`,`aura_spell`,`racemask`,`gender`,`autocast`,`quest_start_status`,`quest_end_status`) VALUES
 (80696,44,26520,0,0,18875469,2,1,64,0); -- Zone Wide
 
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId` = 13 AND `SourceEntry` IN (80704, 80739);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(13, 2, 80704, 0, 0, 31, 0, 3, 43094, 0, 0, 0, '', 'Control Ettin - Target Canyon Ettin'),
+(13, 2, 80704, 0, 1, 31, 0, 3, 43196, 0, 0, 0, '', 'Control Ettin - Target Huge Boulder'),
+(13, 1, 80739, 0, 0, 31, 0, 3, 43197, 0, 0, 0, '', 'Lift Huge Boulder - Target Subdued Canyon Ettin');
+
+DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 80704;
+UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (341, 648, 649, 650, 651, 652, 653, 43196, 43197);
+UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_huge_boulder' WHERE `entry` IN (43196);
+UPDATE `creature_template` SET `VehicleId` = 938 WHERE `entry` = 43197;
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 43094;
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 43094 AND `source_type` = 0;
+INSERT INTO `smart_scripts` (`entryorguid`,`source_type`,`id`,`link`,`event_type`,`event_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action_type`,`action_param1`,`action_param2`,`action_param3`,`action_param4`,`action_param5`,`action_param6`,`target_type`,`target_param1`,`target_param2`,`target_param3`,`target_x`,`target_y`,`target_z`,`target_o`,`comment`) VALUES
+(43094, 0, 0, 0, 8, 0, 100, 0, 80702, 0, 0, 0, 41, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Canyon Ettin - On Spellhit - Despawn');
+
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (80702, 80704, 80739);
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES
+(80704, 'spell_redridge_control_ettin'),
+(80739, 'spell_redridge_lift_huge_boulder');
+
+DELETE FROM `creature_text` WHERE `CreatureID` = 43197;
+INSERT INTO `creature_text` (`CreatureID`, `GroupID`, `ID`, `Text`, `Type`, `Language`, `Probability`, `Emote`, `Duration`, `Sound`, `BroadcastTextId`, `comment`) VALUES
+(43197, 0, 0, 'ROCK NOT SO HEAVY! PUNY HUMIES!', 12, 0, 100, 0, 0, 0, 43218, ''),
+(43197, 1, 0, 'Where trow? TROW ON BRIDGE??', 12, 0, 100, 0, 0, 0, 43220, ''),
+(43197, 2, 0, 'OK! Me trow in water!', 12, 0, 100, 0, 0, 0, 43222, '');
+
 -- marshall marris should be sitting and drinking
 SET @ENTRY := 382;
 UPDATE `creature_template` SET `AIName`='SmartAI' WHERE `entry`=@ENTRY;
@@ -133,8 +160,8 @@ INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`
 (@PATH,2,-9247.676,-2240.278,64.05842,2.583087,42000,0,0,100,0),
 (@PATH,3,-9250.197,-2244.496,64.05842,0,42000,0,0,100,0);
 
--- remove duplicate ettins
-DELETE FROM `creature` WHERE `guid` IN (38740, 38849);
+-- remove duplicate ettins, duplicate master pet tamer
+DELETE FROM `creature` WHERE `guid` IN (38740, 38849, 261577);
 
 -- Pathing for Canyon Ettin Entry: 43094
 SET @NPC := 38410;

--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -168,6 +168,14 @@ INSERT INTO `waypoint_data` (`id`,`point`,`position_x`,`position_y`,`position_z`
 -- remove duplicate ettins, duplicate master pet tamer
 DELETE FROM `creature` WHERE `guid` IN (38740, 38849, 261577);
 
+-- insert second marshal marris
+INSERT INTO `creature` (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `PhaseId`, `modelid`, `equipment_id`, `position_x`, `position_y`, `position_z`, `orientation`, `spawntimesecs`, `spawndist`, `currentwaypoint`, `curhealth`, `curmana`, `MovementType`, `npcflag`, `unit_flags`, `unit_flags3`) VALUES
+(38740, 382, 0, 0, 0, 1, 1, '',0, 1, -9276.96, -2242.86, 64.1778, 1.13446, 120, 0, 0, 1, 0, 0, 0, 0, 0);
+
+DELETE FROM `creature_addon` WHERE `guid` = 38740;
+INSERT INTO `creature_addon` (`guid`, `path_id`, `mount`, `bytes1`, `bytes2`, `emote`, `auras`) VALUES
+(38740, 0, 0, 0, 0, 0, '80699');
+
 -- Pathing for Canyon Ettin Entry: 43094
 SET @NPC := 38410;
 SET @PATH := @NPC * 10;

--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -34,7 +34,8 @@ INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry
 
 DELETE FROM `spell_linked_spell` WHERE `spell_trigger` = 80704;
 UPDATE `creature_template` SET `AIName` = '' WHERE `entry` IN (341, 648, 649, 650, 651, 652, 653, 43196, 43197);
-UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_huge_boulder' WHERE `entry` IN (43196);
+UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_huge_boulder' WHERE `entry` = 43196;
+UPDATE `creature_template` SET `ScriptName` = 'npc_redridge_subdued_ettin' WHERE `entry` = 43197;
 UPDATE `creature_template` SET `VehicleId` = 938 WHERE `entry` = 43197;
 
 UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 43094;

--- a/sql/updates/world/2024_12_02_quest_26520.sql
+++ b/sql/updates/world/2024_12_02_quest_26520.sql
@@ -3,7 +3,7 @@ DELETE FROM `creature_template_addon` WHERE `entry` IN (341,382,43194,43196);
 DELETE FROM `creature_template_addon` WHERE `entry` BETWEEN 648 AND 653;
 INSERT INTO `creature_template_addon` (`entry`,`path_id`,`mount`,`bytes1`,`bytes2`,`emote`,`auras`) VALUES
 (341,0,0,65543,1,0,'80694'),
-(382,0,0,65536,1,0, '80699'),
+(382,0,0,65536,1,0, '80698'),
 (648,0,0,65536,1,0,'80698'),
 (649,0,0,65536,1,0,'80698'),
 (650,0,0,65536,1,0,'80698'),

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -1184,7 +1184,7 @@ bool SpellArea::IsFitToRequirements(Player const* player, uint32 newZone, uint32
                 return false;
 
         if (questEnd)                                // not in expected forbidden quest state
-            if ((questEndStatus & (1 << player->GetQuestStatus(questEnd))))
+            if ((questEndStatus & (1 << player->GetQuestStatus(questEnd))) == 0)
                 return false;
 
         if (auraSpell)                               // not have expected aura

--- a/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
@@ -21,6 +21,7 @@ SD%Complete: 0
 SDComment:
 Script Data End */
 
+#include "MoveSplineInit.h"
 #include "ScriptMgr.h"
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
@@ -29,6 +30,7 @@ enum RedridgeCreature
 {
     NPC_CANYON_ETTIN = 43094,
     NPC_SUBDUED_CANYON_ETTIN = 43197,
+    NPC_HUGE_BOULDER = 43196,
     NPC_FOREMAN_OSLOW = 341,
     NPC_BRIDGE_WORKER_TRENT = 648,
     NPC_BRIDGE_WORKER_DMITRI = 649,
@@ -43,6 +45,7 @@ enum RedridgeSpell
     SPELL_CONTROL_ETTIN = 80704,
     SPELL_CONTROL_ETTIN_2 = 80702,
     SPELL_LIFT_HUGE_BOULDER = 80739,
+    SPELL_LIFT_BOULDER_RIDE = 82566,
     SPELL_EJECT_PASSENGER_1 = 80743
 };
 
@@ -84,7 +87,7 @@ class spell_redridge_lift_huge_boulder : public SpellScript
     }
 };
 
-enum HugeBoulderEvents
+enum HugeBoulder
 {
     EVENT_START_PHASE_IDLE = 1,
     EVENT_FOREMAN_OSLOW_IDLE_TALK = 2,
@@ -94,14 +97,156 @@ enum HugeBoulderEvents
     EVENT_BRIDGE_WORKERS_RESPONSE = 6,
     EVENT_REPOSITION = 7,
     EVENT_LIFT_BOULDER = 8,
+    EVENT_ETTIN_LINE_1 = 9,
+    EVENT_ETTIN_LINE_2 = 10,
+    EVENT_ETTIN_LINE_3 = 11,
+    EVENT_MOVE_TO_WATER = 12,
+    EVENT_THROW_BOULDER = 13,
+    EVENT_PATH_AWAY = 14,
+    EVENT_DONE = 15,
+    EVENT_BRIDGE_WORKERS_COWER = 16,
 
-    EVENT_DEBUG_RESET = 99
+    POINT_NEAR_ROCK = 1,
+    POINT_NEAR_WATER = 2,
+    POINT_UP_PATH = 3
 };
 
-enum HugeBoulderPhases
+static constexpr uint8 const EttinPathToWaterSize = 5;
+G3D::Vector3 const EttinPathToWater[EttinPathToWaterSize] =
 {
-    PHASE_IDLE = 0,
-    PHASE_REMOVE_ROCK = 1
+    { -9270.847f, -2299.5737f, 69.64171f },
+    { -9271.597f, -2309.5737f, 69.89171f },
+    { -9279.847f, -2319.0737f, 66.89171f },
+    { -9304.097f, -2330.5737f, 61.64171f },
+    { -9324.86f,  -2338.94f,   61.2445f  }
+};
+
+static constexpr uint8 const EttinPathUpHillSize = 6;
+G3D::Vector3 const EttinPathUpHill[EttinPathUpHillSize] =
+{
+    { -9308.439f, -2330.975f, 61.716003f },
+    { -9292.939f, -2325.475f, 62.716003f },
+    { -9276.939f, -2316.725f, 68.966f },
+    { -9260.689f, -2312.725f, 75.216f },
+    { -9237.689f, -2313.225f, 78.716f },
+    { -9214.52f,  -2334.01f,  83.6875f }
+};
+
+class npc_redridge_subdued_ettin : public CreatureScript
+{
+public:
+    npc_redridge_subdued_ettin() : CreatureScript("npc_redridge_subdued_ettin") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_redridge_subdued_ettinAI(creature);
+    }
+
+    struct npc_redridge_subdued_ettinAI : public CreatureAI
+    {
+        npc_redridge_subdued_ettinAI(Creature* creature) : CreatureAI(creature) { }
+
+        void Reset() override
+        {
+            me->SetReactState(REACT_PASSIVE);
+            _events.Reset();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            _events.Update(diff);
+
+            while (uint32 eventId = _events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_LIFT_BOULDER:
+                        if (Creature* boulder = me->FindNearestCreature(NPC_HUGE_BOULDER, 10.0f))
+                        {
+                            _boulderGUID = boulder->GetGUID();
+                            boulder->CastSpell(me, SPELL_LIFT_HUGE_BOULDER, false);
+                        }
+                        _events.ScheduleEvent(EVENT_ETTIN_LINE_1, 1s);
+                        break;
+                    case EVENT_ETTIN_LINE_1:
+                        sCreatureTextMgr->SendChat(me, 0);
+                        _events.ScheduleEvent(EVENT_ETTIN_LINE_2, 4s);
+                        break;
+                    case EVENT_ETTIN_LINE_2:
+                        sCreatureTextMgr->SendChat(me, 1);
+                        _events.ScheduleEvent(EVENT_ETTIN_LINE_3, 6s);
+                        break;
+                    case EVENT_ETTIN_LINE_3:
+                        sCreatureTextMgr->SendChat(me, 2);
+                        _events.ScheduleEvent(EVENT_MOVE_TO_WATER, 5s);
+                        break;
+                    case EVENT_MOVE_TO_WATER:
+                    {
+                        Movement::MoveSplineInit init(*me);
+                        Movement::PointsArray path(EttinPathToWater, EttinPathToWater + EttinPathToWaterSize);
+                        init.MovebyPath(path);
+                        me->GetMotionMaster()->LaunchMoveSpline(std::move(init), POINT_NEAR_WATER, MOTION_SLOT_ACTIVE, POINT_MOTION_TYPE);
+                        break;
+                    }
+                    case EVENT_THROW_BOULDER:
+                        me->RemoveAurasDueToSpell(SPELL_LIFT_BOULDER_RIDE);
+                        _events.ScheduleEvent(EVENT_PATH_AWAY, 6s);
+                        break;
+                    case EVENT_PATH_AWAY:
+                    {
+                        // run up path
+                        Movement::MoveSplineInit init(*me);
+                        Movement::PointsArray path(EttinPathUpHill, EttinPathUpHill + EttinPathUpHillSize);
+                        init.MovebyPath(path);
+                        me->GetMotionMaster()->LaunchMoveSpline(std::move(init), POINT_UP_PATH, MOTION_SLOT_ACTIVE, POINT_MOTION_TYPE);
+
+                        // despawn after 15s
+                        _events.ScheduleEvent(EVENT_DONE, 15s);
+                        break;
+                    }
+                    case EVENT_DONE:
+                        if (Creature* boulder = me->GetMap()->GetCreature(_boulderGUID))
+                            boulder->DisappearAndDie();
+
+                        me->DisappearAndDie();
+                        break;
+                }
+            }
+        }
+
+        void CalcExitVehiclePos(Position& pos) override
+        {
+            // location to throw huge boulder
+            // doesn't really work yet; something is strange with vehicle exit code
+            pos.Relocate(-9310.855f, -2366.367f, 55.16147f);
+        }
+
+        void MovementInform(uint32 movementType, uint32 pointId) override
+        {
+            if (movementType != POINT_MOTION_TYPE)
+                return;
+
+            switch (pointId)
+            {
+                case POINT_NEAR_ROCK:
+                    if (Creature* daniel = me->FindNearestCreature(NPC_BRIDGE_WORKER_DANIEL, 20.0f))
+                        me->SetFacingTo(daniel);
+
+                    _events.ScheduleEvent(EVENT_LIFT_BOULDER, 0);
+                    break;
+                case POINT_NEAR_WATER:
+                    me->SetFacingTo(5.0614f);
+                    _events.ScheduleEvent(EVENT_THROW_BOULDER, 1s);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+    private:
+        EventMap _events;
+        ObjectGuid _boulderGUID;
+    };
 };
 
 class npc_redridge_huge_boulder : public CreatureScript
@@ -121,8 +266,7 @@ public:
         void Reset() override
         {
             _events.Reset();
-            _events.SetPhase(PHASE_IDLE);
-            _events.ScheduleEvent(EVENT_START_PHASE_IDLE, 0, 0, PHASE_IDLE);
+            _events.ScheduleEvent(EVENT_START_PHASE_IDLE, 0);
         }
 
         void JustSummoned(Creature* summoned) override
@@ -138,15 +282,11 @@ public:
             if (spell->Id != SPELL_CONTROL_ETTIN)
                 return;
 
-            if (!_events.IsInPhase(PHASE_IDLE))
-                return;
-
             if (Creature* ettin = me->FindNearestCreature(NPC_SUBDUED_CANYON_ETTIN, 20.0f))
             {
                 _ettinGUID = ettin->GetGUID();
                 _events.Reset();
-                _events.SetPhase(PHASE_REMOVE_ROCK);
-                _events.ScheduleEvent(EVENT_REPOSITION, 1s, 0, PHASE_REMOVE_ROCK);
+                _events.ScheduleEvent(EVENT_REPOSITION, 1s);
             }
         }
 
@@ -163,8 +303,8 @@ public:
                         if (!LocateGUIDs())
                             _events.Repeat(500);
 
-                        _events.ScheduleEvent(EVENT_FOREMAN_OSLOW_IDLE_TALK, 45s, 60s, 0, PHASE_IDLE);
-                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        _events.ScheduleEvent(EVENT_FOREMAN_OSLOW_IDLE_TALK, 45s, 60s);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s);
                         break;
                     case EVENT_FOREMAN_OSLOW_IDLE_TALK:
                         if (Creature* foreman = GetForeman())
@@ -179,11 +319,11 @@ public:
                             {
                                 case 1:
                                     sCreatureTextMgr->SendChat(alex, text);
-                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKERS_RESPONSE, 1s, 0, PHASE_IDLE);
+                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKERS_RESPONSE, 1s);
                                     break;
                                 case 2:
                                     sCreatureTextMgr->SendChat(alex, text);
-                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_HARDER, 3s, 0, PHASE_IDLE);
+                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_HARDER, 3s);
                                     break;
                                 default:
                                     sCreatureTextMgr->SendChat(alex, text);
@@ -196,13 +336,13 @@ public:
                         if (Creature* alex = GetAlex())
                         {
                             sCreatureTextMgr->SendChat(alex, 4);
-                            _events.ScheduleEvent(EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE, 4s, 0, PHASE_IDLE);
+                            _events.ScheduleEvent(EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE, 4s);
                         }
                         break;
                     case EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE:
                         if (Creature* matthew = GetMatthew())
                             sCreatureTextMgr->SendChat(matthew, 1, _foremanGUID);
-                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s);
                         break;
                     case EVENT_BRIDGE_WORKERS_RESPONSE:
                         if (Creature* matthew = GetMatthew())
@@ -215,58 +355,141 @@ public:
                             sCreatureTextMgr->SendChat(jess, 0, _foremanGUID);
                         if (Creature* daniel = GetDaniel())
                             sCreatureTextMgr->SendChat(daniel, 0, _foremanGUID);
-                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s);
                         break;
                     case EVENT_REPOSITION:
-                        if (GetEttin())
-                            GetEttin()->GetMotionMaster()->MovePoint(0, me->GetPosition());
-                        if (GetTrent())
-                            GetTrent()->GetMotionMaster()->MovePoint(0, -9281.44, -2285.27, 67.5123);
-                        if (GetDmitri())
-                            GetDmitri()->GetMotionMaster()->MovePoint(0, -9282.8, -2293.28, 67.5089);
-                        if (GetJess())
-                            GetJess()->GetMotionMaster()->MovePoint(0, -9282.27, -2290.95, 67.5319);
-                        if (GetDaniel())
-                            GetDaniel()->GetMotionMaster()->MovePoint(0, -9281.77, -2287.55, 67.5869);
-                        if (GetMatthew())
-                            GetMatthew()->GetMotionMaster()->MovePoint(0, -9280.71, -2283.21, 67.5747);
-                        if (GetAlex())
-                            GetAlex()->GetMotionMaster()->MovePoint(0, -9279.86, -2281.42, 67.5854);
-                        _events.ScheduleEvent(EVENT_LIFT_BOULDER, 200ms, 0, PHASE_REMOVE_ROCK);
+                        if (Creature* ettin = GetEttin())
+                            ettin->GetMotionMaster()->MovePoint(POINT_NEAR_ROCK, -9271.833f, -2290.7075f, 68.538925f);
+
+                        if (Creature* trent = GetTrent())
+                        {
+                            trent->SetAnimKitId(0);
+                            trent->GetMotionMaster()->MovePoint(0, -9281.44f, -2285.27f, 67.5123f);
+                        }
+
+                        if (Creature* dmitri = GetDmitri())
+                        {
+                            dmitri->SetAnimKitId(0);
+                            dmitri->GetMotionMaster()->MovePoint(0, -9282.8f, -2293.28f, 67.5089f);
+                        }
+
+                        if (Creature* jess = GetJess())
+                        {
+                            jess->SetAnimKitId(0);
+                            jess->GetMotionMaster()->MovePoint(0, -9282.27f, -2290.95f, 67.5319f);
+                        }
+
+                        if (Creature* daniel = GetDaniel())
+                        {
+                            daniel->SetAnimKitId(0);
+                            daniel->GetMotionMaster()->MovePoint(0, -9281.77f, -2287.55f, 67.5869f);
+                        }
+
+                        if (Creature* matthew = GetMatthew())
+                        {
+                            matthew->SetAnimKitId(0);
+                            matthew->GetMotionMaster()->MovePoint(0, -9280.71f, -2283.21f, 67.5747f);
+                        }
+
+                        if (Creature* alex = GetAlex())
+                        {
+                            alex->SetAnimKitId(0);
+                            alex->GetMotionMaster()->MovePoint(0, -9279.86f, -2281.42f, 67.5854f);
+                        }
+
+                        _events.ScheduleEvent(EVENT_LIFT_BOULDER, 100ms);
                         break;
                     case EVENT_LIFT_BOULDER:
-                        if (GetEttin())
-                        {
-                            if (!GetEttin()->IsStopped() ||
-                                !GetTrent()   || !GetTrent()->IsStopped()   ||
-                                !GetDmitri()  || !GetDmitri()->IsStopped()  ||
-                                !GetJess()    || !GetJess()->IsStopped()    ||
-                                !GetDaniel()  || !GetDaniel()->IsStopped()  ||
-                                !GetMatthew() || !GetMatthew()->IsStopped() ||
-                                !GetAlex()    || !GetAlex()->IsStopped())
+                        if (Creature* foreman = GetForeman())
+                            if (Creature* ettin = GetEttin())
                             {
-                                _events.Repeat(200ms);
+                                bool allStopped = ettin->IsStopped();
+
+                                if (Creature* trent = GetTrent())
+                                {
+                                    if (trent->IsStopped())
+                                        trent->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && trent->IsStopped();
+                                }
+
+                                if (Creature* dmitri = GetDmitri())
+                                {
+                                    if (dmitri->IsStopped())
+                                        dmitri->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && dmitri->IsStopped();
+                                }
+
+                                if (Creature* jess = GetJess())
+                                {
+                                    if (jess->IsStopped())
+                                        jess->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && jess->IsStopped();
+                                }
+
+                                if (Creature* daniel = GetDaniel())
+                                {
+                                    if (daniel->IsStopped())
+                                        daniel->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && daniel->IsStopped();
+                                }
+
+                                if (Creature* matthew = GetMatthew())
+                                {
+                                    if (matthew->IsStopped())
+                                        matthew->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && matthew->IsStopped();
+                                }
+
+                                if (Creature* alex = GetAlex())
+                                {
+                                    if (alex->IsStopped())
+                                        alex->SetFacingTo(foreman);
+
+                                    allStopped = allStopped && alex->IsStopped();
+                                }
+
+                                if (allStopped)
+                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKERS_COWER, 6s);
+                                else
+                                    _events.Repeat(100ms);
                             }
-                            else
-                            {
-                                GetTrent()->SetFacingTo(GetEttin());
-                                GetDmitri()->SetFacingTo(GetEttin());
-                                GetJess()->SetFacingTo(GetEttin());
-                                GetDaniel()->SetFacingTo(GetEttin());
-                                GetMatthew()->SetFacingTo(GetEttin());
-                                GetAlex()->SetFacingTo(GetEttin());
-                                me->CastSpell(GetEttin(), SPELL_LIFT_HUGE_BOULDER, false);
-                                _events.ScheduleEvent(EVENT_DEBUG_RESET, 5s, 0, PHASE_REMOVE_ROCK);
-                            }
-                        }
                         break;
-                    case EVENT_DEBUG_RESET:
-                        if (GetEttin())
-                        {
-                            GetEttin()->CastSpell(me, SPELL_EJECT_PASSENGER_1, false);
-                            GetEttin()->DisappearAndDie();
-                        }
-                        _events.ScheduleEvent(EVENT_START_PHASE_IDLE, 1s, 0, PHASE_REMOVE_ROCK);
+                    case EVENT_BRIDGE_WORKERS_COWER:
+                        if (Creature* alex = GetAlex())
+                            alex->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                        if (Creature* matthew = GetMatthew())
+                            matthew->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                        if (Creature* trent = GetTrent())
+                            trent->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                        if (Creature* dmitri = GetDmitri())
+                            dmitri->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                        if (Creature* jess = GetJess())
+                            jess->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                        if (Creature* daniel = GetDaniel())
+                            daniel->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+
+                        _events.ScheduleEvent(EVENT_DONE, 18s);
+                        break;
+                    case EVENT_DONE:
+                        if (Creature* alex = GetAlex())
+                            alex->DisappearAndDie();
+                        if (Creature* matthew = GetMatthew())
+                            matthew->DisappearAndDie();
+                        if (Creature* trent = GetTrent())
+                            trent->DisappearAndDie();
+                        if (Creature* dmitri = GetDmitri())
+                            dmitri->DisappearAndDie();
+                        if (Creature* jess = GetJess())
+                            jess->DisappearAndDie();
+                        if (Creature* daniel = GetDaniel())
+                            daniel->DisappearAndDie();
+
+                        _events.Reset();
                         break;
                 }
             }
@@ -352,5 +575,6 @@ void AddSC_redridge_mountains()
 {
     RegisterSpellScript(spell_redridge_control_ettin);
     RegisterSpellScript(spell_redridge_lift_huge_boulder);
+    new npc_redridge_subdued_ettin();
     new npc_redridge_huge_boulder();
 }

--- a/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
@@ -463,19 +463,56 @@ public:
                             }
                         break;
                     case EVENT_BRIDGE_WORKERS_COWER:
+                    {
+                        uint32 a = urand(0, 5);
+                        uint32 b = urand(0, 5);
+                        if (a == b)
+                            b = (a + 2) % 6;
+
                         if (Creature* alex = GetAlex())
+                        {
                             alex->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 0 || b == 0)
+                                alex->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         if (Creature* matthew = GetMatthew())
+                        {
                             matthew->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 1 || b == 1)
+                                matthew->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         if (Creature* trent = GetTrent())
+                        {
                             trent->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 2 || b == 2)
+                                trent->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         if (Creature* dmitri = GetDmitri())
+                        {
                             dmitri->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 3 || b == 3)
+                                dmitri->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         if (Creature* jess = GetJess())
+                        {
                             jess->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 4 || b == 4)
+                                jess->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         if (Creature* daniel = GetDaniel())
+                        {
                             daniel->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 431);
+                            if (a == 5 || b == 5)
+                                daniel->MonsterSay(int32(43230 + urand(0, 2)), LANG_UNIVERSAL, ObjectGuid::Empty);
+                        }
+
                         break;
+                    }
                     case EVENT_FOREMAN_GET_UP:
                         if (Creature* foreman = GetForeman())
                             foreman->SetStandState(UNIT_STAND_STATE_STAND);

--- a/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
@@ -25,6 +25,246 @@ Script Data End */
 #include "ScriptedCreature.h"
 #include "ScriptedEscortAI.h"
 
+enum RedridgeCreature
+{
+    NPC_CANYON_ETTIN = 43094,
+    NPC_FOREMAN_OSLOW = 341,
+    NPC_BRIDGE_WORKER_TRENT = 648,
+    NPC_BRIDGE_WORKER_DMITRI = 649,
+    NPC_BRIDGE_WORKER_JESS = 650,
+    NPC_BRIDGE_WORKER_DANIEL = 651,
+    NPC_BRIDGE_WORKER_MATTHEW = 652,
+    NPC_BRIDGE_WORKER_ALEX = 653,
+};
+
+enum RedridgeSpell
+{
+    SPELL_CONTROL_ETTIN_2 = 80702
+};
+
+class spell_redridge_control_ettin : public SpellScript
+{
+    PrepareSpellScript(spell_redridge_control_ettin);
+
+    void HandleScriptEffect(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        if (!caster || !caster->IsPlayer())
+            return;
+
+        if (Creature* target = GetHitCreature())
+            if (target->GetEntry() == NPC_CANYON_ETTIN)
+                caster->CastSpell(target, SPELL_CONTROL_ETTIN_2, false);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_redridge_control_ettin::HandleScriptEffect, EFFECT_1, SPELL_EFFECT_DUMMY);
+    }
+};
+
+class spell_redridge_lift_huge_boulder : public SpellScript
+{
+    PrepareSpellScript(spell_redridge_lift_huge_boulder);
+
+    void HandleScriptEffect(SpellEffIndex /*effIndex*/)
+    {
+        if (Unit* caster = GetCaster())
+            if (Creature* target = GetHitCreature())
+                caster->CastSpell(target, uint32(GetSpellInfo()->GetEffect(EFFECT_0)->BasePoints), false);
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_redridge_lift_huge_boulder::HandleScriptEffect, EFFECT_0, SPELL_EFFECT_SCRIPT_EFFECT);
+    }
+};
+
+enum HugeBoulderEvents
+{
+    EVENT_START_PHASE_IDLE = 1,
+    EVENT_FOREMAN_OSLOW_IDLE_TALK = 2,
+    EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK = 3,
+    EVENT_BRIDGE_WORKER_ALEX_HARDER = 4,
+    EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE = 5,
+    EVENT_BRIDGE_WORKERS_RESPONSE = 6
+};
+
+enum HugeBoulderPhases
+{
+    PHASE_IDLE = 0
+};
+
+class npc_redridge_huge_boulder : public CreatureScript
+{
+public:
+    npc_redridge_huge_boulder() : CreatureScript("npc_redridge_huge_boulder") { }
+
+    CreatureAI* GetAI(Creature* creature) const override
+    {
+        return new npc_redridge_huge_boulderAI(creature);
+    }
+
+    struct npc_redridge_huge_boulderAI : public CreatureAI
+    {
+        npc_redridge_huge_boulderAI(Creature* creature) : CreatureAI(creature) { }
+
+        void Reset() override
+        {
+            _events.Reset();
+            _events.SetPhase(PHASE_IDLE);
+            _events.ScheduleEvent(EVENT_START_PHASE_IDLE, 0, 0, PHASE_IDLE);
+        }
+
+        void JustSummoned(Creature* summoned) override
+        {
+            Reset();
+        }
+
+        void UpdateAI(uint32 diff) override
+        {
+            _events.Update(diff);
+
+            while (uint32 eventId = _events.ExecuteEvent())
+            {
+                switch (eventId)
+                {
+                    case EVENT_START_PHASE_IDLE:
+                        // wait for everyone to appear
+                        if (!LocateGUIDs())
+                            _events.Repeat(500);
+
+                        _events.ScheduleEvent(EVENT_FOREMAN_OSLOW_IDLE_TALK, 45s, 60s, 0, PHASE_IDLE);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        break;
+                    case EVENT_FOREMAN_OSLOW_IDLE_TALK:
+                        if (Creature* foreman = GetForeman())
+                            sCreatureTextMgr->SendChat(foreman, 0);
+                        _events.Repeat(45s, 60s);
+                        break;
+                    case EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK:
+                        if (Creature* alex = GetAlex())
+                        {
+                            uint32 text = urand(0, 3);
+                            switch (text)
+                            {
+                                case 1:
+                                    sCreatureTextMgr->SendChat(alex, text);
+                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKERS_RESPONSE, 1s, 0, PHASE_IDLE);
+                                    break;
+                                case 2:
+                                    sCreatureTextMgr->SendChat(alex, text);
+                                    _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_HARDER, 3s, 0, PHASE_IDLE);
+                                    break;
+                                default:
+                                    sCreatureTextMgr->SendChat(alex, text);
+                                    _events.Repeat(10s);
+                                    break;
+                            }
+                        }
+                        break;
+                    case EVENT_BRIDGE_WORKER_ALEX_HARDER:
+                        if (Creature* alex = GetAlex())
+                        {
+                            sCreatureTextMgr->SendChat(alex, 4);
+                            _events.ScheduleEvent(EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE, 4s, 0, PHASE_IDLE);
+                        }
+                        break;
+                    case EVENT_BRIDGE_WORKER_MATTHEW_HARDER_RESPONSE:
+                        if (Creature* matthew = GetMatthew())
+                            sCreatureTextMgr->SendChat(matthew, 1, _foremanGUID);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        break;
+                    case EVENT_BRIDGE_WORKERS_RESPONSE:
+                        if (Creature* matthew = GetMatthew())
+                            sCreatureTextMgr->SendChat(matthew, 0, _foremanGUID);
+                        if (Creature* trent = GetTrent())
+                            sCreatureTextMgr->SendChat(trent, 0, _foremanGUID);
+                        if (Creature* dmitri = GetDmitri())
+                            sCreatureTextMgr->SendChat(dmitri, 0, _foremanGUID);
+                        if (Creature* jess = GetJess())
+                            sCreatureTextMgr->SendChat(jess, 0, _foremanGUID);
+                        if (Creature* daniel = GetDaniel())
+                            sCreatureTextMgr->SendChat(daniel, 0, _foremanGUID);
+                        _events.ScheduleEvent(EVENT_BRIDGE_WORKER_ALEX_IDLE_TALK, 20s, 30s, 0, PHASE_IDLE);
+                        break;
+                }
+            }
+        }
+
+        bool LocateGUIDs()
+        {
+            if (Creature* foreman = me->FindNearestCreature(NPC_FOREMAN_OSLOW, 10.0f))
+                if (Creature* alex = me->FindNearestCreature(NPC_BRIDGE_WORKER_ALEX, 10.0f))
+                    if (Creature* matthew = me->FindNearestCreature(NPC_BRIDGE_WORKER_MATTHEW, 10.0f))
+                        if (Creature* trent = me->FindNearestCreature(NPC_BRIDGE_WORKER_TRENT, 10.0f))
+                            if (Creature* dmitri = me->FindNearestCreature(NPC_BRIDGE_WORKER_DMITRI, 10.0f))
+                                if (Creature* jess = me->FindNearestCreature(NPC_BRIDGE_WORKER_JESS, 10.0f))
+                                    if (Creature* daniel = me->FindNearestCreature(NPC_BRIDGE_WORKER_DANIEL, 10.0f))
+                                    {
+                                        _foremanGUID = foreman->GetGUID();
+                                        _alexGUID = alex->GetGUID();
+                                        _matthewGUID = matthew->GetGUID();
+                                        _trentGUID = trent->GetGUID();
+                                        _dmitriGUID = dmitri->GetGUID();
+                                        _jessGUID = jess->GetGUID();
+                                        _danielGUID = daniel->GetGUID();
+                                        return true;
+                                    }
+
+            return false;
+        }
+
+        Creature* GetForeman()
+        {
+            return me->GetMap()->GetCreature(_foremanGUID);
+        }
+
+        Creature* GetAlex()
+        {
+            return me->GetMap()->GetCreature(_alexGUID);
+        }
+
+        Creature* GetMatthew()
+        {
+            return me->GetMap()->GetCreature(_matthewGUID);
+        }
+
+        Creature* GetTrent()
+        {
+            return me->GetMap()->GetCreature(_trentGUID);
+        }
+
+        Creature* GetDmitri()
+        {
+            return me->GetMap()->GetCreature(_dmitriGUID);
+        }
+
+        Creature* GetJess()
+        {
+            return me->GetMap()->GetCreature(_jessGUID);
+        }
+
+        Creature* GetDaniel()
+        {
+            return me->GetMap()->GetCreature(_danielGUID);
+        }
+
+    private:
+        EventMap _events;
+        ObjectGuid _foremanGUID;
+        ObjectGuid _alexGUID;
+        ObjectGuid _matthewGUID;
+        ObjectGuid _trentGUID;
+        ObjectGuid _dmitriGUID;
+        ObjectGuid _jessGUID;
+        ObjectGuid _danielGUID;
+    };
+};
+
 void AddSC_redridge_mountains()
 {
+    RegisterSpellScript(spell_redridge_control_ettin);
+    RegisterSpellScript(spell_redridge_lift_huge_boulder);
+    new npc_redridge_huge_boulder();
 }

--- a/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
+++ b/src/server/scripts/EasternKingdoms/zone_redridge_mountains.cpp
@@ -287,6 +287,7 @@ public:
 
             if (Creature* ettin = me->FindNearestCreature(NPC_SUBDUED_CANYON_ETTIN, 20.0f))
             {
+                _playerGUID = caster->GetGUID();
                 _ettinGUID = ettin->GetGUID();
                 _events.Reset();
                 _events.ScheduleEvent(EVENT_REPOSITION, 1s);
@@ -523,6 +524,10 @@ public:
                             foreman->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 64);
                         break;
                     case EVENT_DONE:
+                        // quest credit
+                        if (Player* player = ObjectAccessor::FindPlayer(me->GetMap(), _playerGUID))
+                            player->RewardPlayerAndGroupAtEvent(NPC_FOREMAN_OSLOW, player);
+
                         if (Creature* alex = GetAlex())
                             alex->DisappearAndDie();
                         if (Creature* matthew = GetMatthew())
@@ -618,6 +623,7 @@ public:
 
     private:
         EventMap _events;
+        ObjectGuid _playerGUID;
         ObjectGuid _foremanGUID;
         ObjectGuid _alexGUID;
         ObjectGuid _matthewGUID;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Adds script for [Saving Foreman Oslow](https://www.wowhead.com/quest=26520) quest event
- Adds some waypoints for the town guards
  - Ref: https://github.com/TrinityCore/TrinityCore/blob/1fb4acc25ae89360e71d33a8f7cba99bcc028b32/sql/old/7/world/01_2018_02_19/2017_07_04_00_world.sql
- Fixes cast bar and visual for [Control Ettin](https://www.wowhead.com/spell=80704)
- Fixes visibility of some NPCs based on completion of [Saving Foreman Oslow](https://www.wowhead.com/quest=26520)
- Fixes bug with using data from `spell_area` table
  - Ref: https://github.com/The-Legion-Preservation-Project/AshamaneCore/commit/0d358200d0ed84cb6269d8fb104276fcb0c7995b
- Removes duplicate ettin creatures

**Issues addressed:**

Closes #208 

**Tests performed:**

tested in-game

**Known issues and TODO list:**

- Boulder throw looks bad - not sure how to fix so it throws into water
- Spell effect summon (like on [Control Ettin](https://www.wowhead.com/spell=80702)) behaves strangely
  - It works, but the old creature stays around for too long, and the position of the new creature is inaccurate


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
