### PR TITLE
Core/Movement: fix default creature movement swim

### DIFF
--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2521,10 +2521,6 @@ void Creature::setDeathState(DeathState s)
 
     if (s == JUST_DIED)
     {
-        // Disable hover after die
-        if (HasUnitMovementFlag(MOVEMENTFLAG_HOVER))
-            SetHover(false);
-
         m_corpseRemoveTime = GameTime::GetGameTime() + m_corpseDelay;
         int32 _respawnDelay = m_respawnDelay;
 
@@ -2565,8 +2561,12 @@ void Creature::setDeathState(DeathState s)
         if (m_formation && m_formation->getLeader() == this)
             m_formation->FormationReset(true);
 
-        if (CanFly() || IsFlying() || (GetMiscStandValue() & UNIT_BYTE1_FLAG_HOVER))
-            i_motionMaster.MoveFall();
+        bool needsFalling = (IsFlying() || IsHovering()) && !IsUnderWater() && !HasUnitState(UNIT_STATE_ROOT);
+        SetHover(false);
+        SetDisableGravity(false, false);
+
+        if (needsFalling)
+            GetMotionMaster()->MoveFall();
 
         Unit::setDeathState(CORPSE);
     }

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -25155,7 +25155,7 @@ bool Unit::SetHover(bool enable)
     {
         if (!IsPlayer())
             RemoveUnitMovementFlag(MOVEMENTFLAG_HOVER);
-        if (hoverHeight)
+        if (hoverHeight && (!isDying() || GetTypeId() != TYPEID_UNIT))
         {
             float newZ = GetPositionZ() - hoverHeight;
             UpdateAllowedPositionZ(GetPositionX(), GetPositionY(), newZ);

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -828,13 +828,17 @@ void ObjectMgr::LoadCreatureTemplates()
             creatureTemplate.Movement.Ground = static_cast<CreatureGroundMovementType>(fields[index].GetUInt8());
         index++;
 
-        creatureTemplate.Movement.Swim = fields[index++].GetBool();
+        if (!fields[index].IsNull())
+            creatureTemplate.Movement.Swim = fields[index].GetBool();
+        index++;
 
         if (!fields[index].IsNull())
             creatureTemplate.Movement.Flight = static_cast<CreatureFlightMovementType>(fields[index].GetUInt8());
         index++;
 
-        creatureTemplate.Movement.Rooted = fields[index++].GetBool();
+        if (!fields[index].IsNull())
+            creatureTemplate.Movement.Rooted = fields[index].GetBool();
+        index++;
 
         if (!fields[index].IsNull())
             creatureTemplate.Movement.Random = static_cast<CreatureRandomMovementType>(fields[index].GetUInt8());


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Fixes creature movement loading to only override default swim (true) when `creature_template_movement` record exists in db
- Ref: https://github.com/TrinityCore/TrinityCore/commit/a91edcb9524b53f027a8ef8c247a443a9bb42f1e

**Issues addressed:**

Closes #227 
Closes #228
Closes #229 

**Tests performed:**

tested in-game; confirm `Swim: true` in `.npc info`


**Known issues and TODO list:** (add/remove lines as needed)

- May want to follow up with https://github.com/TrinityCore/TrinityCore/commit/ee620856ad2918ae7ce91a37a980d9f2129a074a


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
