### PR TITLE
Core/Movement: corrected animation tier handling

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -432,10 +432,6 @@ void CreatureAI::SetFlyMode(bool fly)
 {
     me->SetCanFly(fly);
     me->SetDisableGravity(fly);
-    if (fly)
-        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
-    else
-        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
 }
 
 AISpellInfoType::AISpellInfoType() : target(AITARGET_SELF), condition(AICOND_COMBAT)

--- a/src/server/game/AI/SmartScripts/SmartAI.cpp
+++ b/src/server/game/AI/SmartScripts/SmartAI.cpp
@@ -843,11 +843,6 @@ void SmartAI::SetFly(bool fly)
 {
     me->SetCanFly(fly);
     me->SetDisableGravity(fly);
-
-    if (fly)
-        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
-    else
-        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
 }
 
 void SmartAI::SetSwim(bool swim)

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2563,7 +2563,7 @@ void Creature::setDeathState(DeathState s)
 
         bool needsFalling = (IsFlying() || IsHovering()) && !IsUnderWater() && !HasUnitState(UNIT_STATE_ROOT);
         SetHover(false);
-        SetDisableGravity(false); //, false);
+        SetDisableGravity(false, false);
 
         if (needsFalling)
             GetMotionMaster()->MoveFall();

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -2563,7 +2563,7 @@ void Creature::setDeathState(DeathState s)
 
         bool needsFalling = (IsFlying() || IsHovering()) && !IsUnderWater() && !HasUnitState(UNIT_STATE_ROOT);
         SetHover(false);
-        SetDisableGravity(false, false);
+        SetDisableGravity(false); //, false);
 
         if (needsFalling)
             GetMotionMaster()->MoveFall();

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -6958,9 +6958,6 @@ void Player::BuildPlayerRepop()
     StopMirrorTimers();                                     //disable timers(bars)
 
     SetFloatValue(UNIT_FIELD_BOUNDING_RADIUS, float(1.0f));   //see radius of death player?
-
-    // set and clear other
-    SetMiscStandValue(UNIT_BYTE1_FLAG_ALWAYS_STAND);
 }
 
 void Player::ResurrectPlayer(float restore_percent, bool applySickness)
@@ -6974,7 +6971,6 @@ void Player::ResurrectPlayer(float restore_percent, bool applySickness)
     // speed change, land walk
 
     // remove death flag + set aura
-    SetMiscStandValue(0);
     if (getRace() == RACE_NIGHTELF)
         RemoveAurasDueToSpell(20584);                       // speed bonuses
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -639,6 +639,9 @@ void Unit::UpdateSplineMovement(uint32 t_diff)
     {
         waitOnSeat = false;
         DisableSpline();
+
+        if (Optional<AnimTier> animTier = movespline->GetAnimation())
+            SetAnimTier(*animTier);
     }
 
     m_movesplineTimer.Update(t_diff);
@@ -21850,12 +21853,17 @@ void Unit::SendDurabilityLoss(Player* receiver, uint32 percent)
     receiver->SendDirectMessage(durabilityDamage.Write());
 }
 
-void Unit::SetAnimTier(uint32 tier)
+void Unit::SetAnimTier(AnimTier animTier, bool notifyClient /*=true*/)
 {
-    WorldPackets::Update::SetAnimTimer packet;
-    packet.Tier = tier;
-    packet.Unit = GetGUID();
-    SendMessageToSet(packet.Write(), true);
+    SetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER, AsUnderlyingType(animTier));
+
+    if (notifyClient)
+    {
+        WorldPackets::Update::SetAnimTimer packet;
+        packet.Tier = AsUnderlyingType(animTier);
+        packet.Unit = GetGUID();
+        SendMessageToSet(packet.Write(), true);
+    }
 }
 
 void Unit::PlayOneShotAnimKit(uint16 animKitID)
@@ -24904,25 +24912,19 @@ bool Unit::SetWalk(bool enable)
     return true;
 }
 
-bool Unit::SetDisableGravity(bool disable)
+bool Unit::SetDisableGravity(bool disable, bool updateAnimationTier /*= true*/)
 {
     if (disable == IsLevitating())
         return false;
 
-    if (!IsPlayer())
+    if (disable)
     {
-        if (disable)
-        {
-            AddUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
-            RemoveUnitMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_SPLINE_ELEVATION);
-            SetFall(false);
-        }
-        else
-        {
-            RemoveUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
-            if (!HasUnitMovementFlag(MOVEMENTFLAG_CAN_FLY))
-                SetFall(true);
-        }
+        AddUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
+        RemoveUnitMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_SPLINE_ELEVATION);
+    }
+    else
+    {
+        RemoveUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
     }
 
     static OpcodeServer const gravityOpcodeTable[2][2] =
@@ -24944,6 +24946,16 @@ bool Unit::SetDisableGravity(bool disable)
         WorldPackets::Movement::MoveSplineSetFlag packet(gravityOpcodeTable[disable][0]);
         packet.MoverGUID = GetGUID();
         SendMessageToSet(packet.Write(), true);
+    }
+
+    if (IsCreature() && updateAnimationTier && IsAlive() && !HasUnitState(UNIT_STATE_ROOT) && !ToCreature()->GetMovementTemplate().IsRooted())
+    {
+        if (IsLevitating())
+            SetAnimTier(AnimTier::Fly);
+        else if (IsHovering())
+            SetAnimTier(AnimTier::Hover);
+        else
+            SetAnimTier(AnimTier::Ground);
     }
 
     return true;
@@ -25106,45 +25118,41 @@ bool Unit::SetFeatherFall(bool enable)
     return true;
 }
 
-bool Unit::SetHover(bool enable)
+bool Unit::SetHover(bool enable, bool updateAnimationTier /*= true*/)
 {
     if (enable == HasUnitMovementFlag(MOVEMENTFLAG_HOVER))
         return false;
 
     float hoverHeight = GetFloatValue(UNIT_FIELD_HOVER_HEIGHT);
 
-    //! Unconfirmed for players:
-    if (!IsPlayer())
+    if (enable)
     {
-        if (enable)
-        {
-            if (!IsLevitating())
-                m_updateFlag |= UPDATEFLAG_PLAY_HOVER_ANIM;
-            // SetMiscStandFlags(UNIT_BYTE1_FLAG_HOVER);
-            if (hoverHeight)
-                UpdateHeight(GetPositionZ() + hoverHeight);
-        }
-        else
-        {
-            if (!IsLevitating())
-                m_updateFlag &= ~UPDATEFLAG_PLAY_HOVER_ANIM;
-            // RemoveMiscStandFlags(UNIT_BYTE1_FLAG_HOVER);
-            if (hoverHeight)
-            {
-                float newZ = GetPositionZ() - hoverHeight;
-                UpdateAllowedPositionZ(GetPositionX(), GetPositionY(), newZ);
-                UpdateHeight(newZ);
-            }
-        }
-
         if (!IsLevitating())
+            m_updateFlag |= UPDATEFLAG_PLAY_HOVER_ANIM;
+        // SetMiscStandFlags(UNIT_BYTE1_FLAG_HOVER);
+        if (hoverHeight)
+            UpdateHeight(GetPositionZ() + hoverHeight);
+    }
+    else
+    {
+        if (!IsLevitating())
+            m_updateFlag &= ~UPDATEFLAG_PLAY_HOVER_ANIM;
+        // RemoveMiscStandFlags(UNIT_BYTE1_FLAG_HOVER);
+        if (hoverHeight)
         {
-            WorldPackets::Misc::SetPlayHoverAnim playHoverAnim;
-            playHoverAnim.UnitGUID = GetGUID();
-            playHoverAnim.PlayHoverAnim = enable;
-            SendMessageToSet(playHoverAnim.Write(), true);
+            float newZ = GetPositionZ() - hoverHeight;
+            UpdateAllowedPositionZ(GetPositionX(), GetPositionY(), newZ);
+            UpdateHeight(newZ);
         }
     }
+
+//    if (!IsLevitating())
+//    {
+//        WorldPackets::Misc::SetPlayHoverAnim playHoverAnim;
+//        playHoverAnim.UnitGUID = GetGUID();
+//        playHoverAnim.PlayHoverAnim = enable;
+//        SendMessageToSet(playHoverAnim.Write(), true);
+//    }
 
     if (enable)
     {
@@ -25188,6 +25196,16 @@ bool Unit::SetHover(bool enable)
         WorldPackets::Movement::MoveSplineSetFlag packet(hoverOpcodeTable[enable][0]);
         packet.MoverGUID = GetGUID();
         SendMessageToSet(packet.Write(), true);
+    }
+
+    if (IsCreature() && updateAnimationTier && IsAlive() && !HasUnitState(UNIT_STATE_ROOT) && !ToCreature()->GetMovementTemplate().IsRooted())
+    {
+        if (IsLevitating())
+            SetAnimTier(AnimTier::Fly);
+        else if (IsHovering())
+            SetAnimTier(AnimTier::Hover);
+        else
+            SetAnimTier(AnimTier::Ground);
     }
 
     return true;

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -24394,7 +24394,6 @@ void Unit::_ExitVehicle(Position const* exitPosition)
     // This should be done before dismiss, because there may be some aura removal
     m_vehicle = nullptr;
 
-    SetDisableGravity(false, true);
     SetControlled(false, UNIT_STATE_ROOT);      // SMSG_MOVE_FORCE_UNROOT, ~MOVEMENTFLAG_ROOT
 
     Position pos;
@@ -24905,28 +24904,32 @@ bool Unit::SetWalk(bool enable)
     return true;
 }
 
-bool Unit::SetDisableGravity(bool disable, bool isPlayer)
+bool Unit::SetDisableGravity(bool disable)
 {
     if (disable == IsLevitating())
         return false;
 
-    if (!IsPlayer() || isPlayer)
+    if (!IsPlayer())
     {
         if (disable)
         {
             AddUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
             RemoveUnitMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_SPLINE_ELEVATION);
-            SetFall(false, isPlayer);
+            SetFall(false);
         }
         else
         {
             RemoveUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
             if (!HasUnitMovementFlag(MOVEMENTFLAG_CAN_FLY))
-                SetFall(true, isPlayer);
+                SetFall(true);
         }
     }
 
-    static OpcodeServer const gravityOpcodeTable[2][2] = {{SMSG_MOVE_SPLINE_ENABLE_GRAVITY, SMSG_MOVE_ENABLE_GRAVITY}, {SMSG_MOVE_SPLINE_DISABLE_GRAVITY, SMSG_MOVE_DISABLE_GRAVITY}};
+    static OpcodeServer const gravityOpcodeTable[2][2] =
+    {
+        { SMSG_MOVE_SPLINE_ENABLE_GRAVITY, SMSG_MOVE_ENABLE_GRAVITY },
+        { SMSG_MOVE_SPLINE_DISABLE_GRAVITY, SMSG_MOVE_DISABLE_GRAVITY }
+    };
 
     if (Player* playerMover = Unit::ToPlayer(GetUnitBeingMoved()))
     {
@@ -24946,7 +24949,7 @@ bool Unit::SetDisableGravity(bool disable, bool isPlayer)
     return true;
 }
 
-bool Unit::SetFall(bool enable, bool isPlayer)
+bool Unit::SetFall(bool enable)
 {
     if (enable && IsLevitating()) // If disable gravity not use Feather Fall
         return false;
@@ -24954,7 +24957,7 @@ bool Unit::SetFall(bool enable, bool isPlayer)
     if (enable == HasUnitMovementFlag(MOVEMENTFLAG_FALLING))
         return false;
 
-    if (!IsPlayer() || isPlayer)
+    if (!IsPlayer())
     {
         if (enable)
         {

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1366,7 +1366,8 @@ class Unit : public WorldObject
 
         void SendDurabilityLoss(Player* receiver, uint32 percent);
 
-        void SetAnimTier(uint32 tier);
+        AnimTier GetAnimTier() const { return AnimTier(GetByteValue(UNIT_FIELD_BYTES_1, UNIT_BYTES_1_OFFSET_ANIM_TIER)); }
+        void SetAnimTier(AnimTier animTier, bool notifyClient = true);
         void PlayOneShotAnimKit(uint16 animKitID);
         void SetAnimKitId(uint16 animKitID);
         uint16 GetAIAnimKitId() const override { return _aiAnimKitId; }
@@ -1559,13 +1560,13 @@ class Unit : public WorldObject
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING);}
         bool IsHovering() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_HOVER);}
         bool SetWalk(bool enable);
-        bool SetDisableGravity(bool disable);
+        bool SetDisableGravity(bool disable, bool updateAnimationTier = true);
         bool SetFall(bool enable);
         bool SetSwim(bool enable);
         bool SetCanFly(bool apply);
         bool SetWaterWalking(bool enable);
         bool SetFeatherFall(bool enable);
-        bool SetHover(bool enable);
+        bool SetHover(bool enable, bool updateAnimationTier = true);
         bool SetCollision(bool disable);
 
         void SetInFront(Unit const* target);

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1559,8 +1559,8 @@ class Unit : public WorldObject
         bool IsWalking() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_WALKING);}
         bool IsHovering() const { return m_movementInfo.HasMovementFlag(MOVEMENTFLAG_HOVER);}
         bool SetWalk(bool enable);
-        bool SetDisableGravity(bool disable, bool isPlayer = false);
-        bool SetFall(bool enable, bool isPlayer = false);
+        bool SetDisableGravity(bool disable);
+        bool SetFall(bool enable);
         bool SetSwim(bool enable);
         bool SetCanFly(bool apply);
         bool SetWaterWalking(bool enable);

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -80,13 +80,14 @@ enum UnitBytes2Offsets : uint8
     UNIT_BYTES_2_OFFSET_SHAPESHIFT_FORM = 3,
 };
 
-// byte flags value (UNIT_FIELD_BYTES_1, 3) ((cainfo->bytes1 >> 24) & 0xFF)
-enum UnitBytes1_Flags
+// UNIT_FIELD_BYTES_1 (UNIT_BYTES_1_OFFSET_ANIM_TIER)
+enum class AnimTier : uint8
 {
-    UNIT_BYTE1_FLAG_ALWAYS_STAND    = 0x01,
-    UNIT_BYTE1_FLAG_HOVER           = 0x02,
-    UNIT_BYTE1_FLAG_UNK_3           = 0x04,
-    UNIT_BYTE1_FLAG_ALL             = 0xFF
+    Ground      = 0, // plays ground tier animations
+    Swim        = 1, // falls back to ground tier animations, not handled by the client, should never appear in sniffs, will prevent tier change animations from playing correctly if used
+    Hover       = 2, // plays flying tier animations or falls back to ground tier animations, automatically enables hover clientside when entering visibility with this value
+    Fly         = 3, // plays flying tier animations
+    Submerged   = 4
 };
 
 // low byte (0 from 0..3) of UNIT_FIELD_BYTES_2

--- a/src/server/game/Entities/Vehicle/Vehicle.cpp
+++ b/src/server/game/Entities/Vehicle/Vehicle.cpp
@@ -1083,6 +1083,9 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
             player->UnsummonPetTemporaryIfAny();
     }
 
+    if (veSeat->Flags & VEHICLE_SEAT_FLAG_DISABLE_GRAVITY)
+        Passenger->SetDisableGravity(true);
+
     if (veSeat->Flags & VEHICLE_SEAT_FLAG_HIDE_PASSENGER)
         if (!(Target->IsCreature() && Target->ToCreature()->GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_VEHICLE_ATTACKABLE_PASSENGERS))
         {
@@ -1128,7 +1131,6 @@ bool VehicleJoinEvent::Execute(uint64, uint32)
     }
 
     Passenger->SendBreakTarget(Target);                      // SMSG_BREAK_TARGET
-    Passenger->SetDisableGravity(true, true);
     Passenger->SetControlled(true, UNIT_STATE_ROOT);         // SMSG_FORCE_ROOT - In some cases we send SMSG_MOVE_SPLINE_ROOT here (for creatures)
 
     // also adds MOVEMENTFLAG_ROOT

--- a/src/server/game/Movement/MotionMaster.cpp
+++ b/src/server/game/Movement/MotionMaster.cpp
@@ -402,7 +402,7 @@ void MotionMaster::MoveLand(uint32 id, Position const& pos)
 
     Movement::MoveSplineInit init(*_owner);
     init.MoveTo(x, y, z);
-    init.SetAnimation(Movement::ToGround);
+    init.SetAnimation(AnimTier::Ground);
     init.Launch();
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_ACTIVE);
 }
@@ -413,7 +413,7 @@ void MotionMaster::MoveTakeoff(uint32 id, float x, float y, float z)
 
     Movement::MoveSplineInit init(*_owner);
     init.MoveTo(x, y, z);
-    init.SetAnimation(Movement::ToFly);
+    init.SetAnimation(AnimTier::Hover);
     init.Launch();
     Mutate(new EffectMovementGenerator(id), MOTION_SLOT_ACTIVE);
 }
@@ -620,7 +620,7 @@ void MotionMaster::MoveCirclePath(float x, float y, float z, float radius, bool 
     if (_owner->IsFlying())
     {
         init.SetFly();
-        init.SetAnimation(Movement::ToFly);
+        init.SetAnimation(AnimTier::Hover);
     }
     else
         init.SetWalk(true);

--- a/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
+++ b/src/server/game/Movement/MovementGenerators/WaypointMovementGenerator.cpp
@@ -215,10 +215,10 @@ bool WaypointMovementGenerator<Creature>::StartMove(Creature& creature)
     switch (waypoint.move_type)
     {
         case WAYPOINT_MOVE_TYPE_LAND:
-            init.SetAnimation(Movement::ToGround);
+            init.SetAnimation(AnimTier::Ground);
             break;
         case WAYPOINT_MOVE_TYPE_TAKEOFF:
-            init.SetAnimation(Movement::ToFly);
+            init.SetAnimation(AnimTier::Hover);
             break;
         case WAYPOINT_MOVE_TYPE_RUN:
             init.SetWalk(false);

--- a/src/server/game/Movement/Spline/MoveSpline.cpp
+++ b/src/server/game/Movement/Spline/MoveSpline.cpp
@@ -88,7 +88,7 @@ Location MoveSpline::ComputePosition() const
     }
     else
     {
-        if (!splineflags.hasFlag(MoveSplineFlag::OrientationFixed | MoveSplineFlag::Falling | MoveSplineFlag::Unknown0))
+        if (!splineflags.hasFlag(MoveSplineFlag::OrientationFixed | MoveSplineFlag::Falling | MoveSplineFlag::Unknown_0x8))
         {
             G3D::Vector3 hermite;
             spline.evaluate_derivative(point_Idx, u, hermite);
@@ -249,6 +249,7 @@ void MoveSpline::Initialize(const MoveSplineInitArgs& args)
     point_Idx_offset = args.path_Idx_offset;
     initialOrientation = args.initialOrientation;
     spell_effect_extra = args.spellEffectExtra;
+    anim_tier = args.animTier;
     splineIsFacingOnly = args.path.size() == 2 && args.facing.type != MONSTER_MOVE_NORMAL && ((args.path[1] - args.path[0]).length() < 0.1f);
 
     onTransport = false;

--- a/src/server/game/Movement/Spline/MoveSpline.h
+++ b/src/server/game/Movement/Spline/MoveSpline.h
@@ -106,6 +106,7 @@ namespace Movement
 
         bool walk;
         float _velocity;
+        Optional<AnimTierTransition> anim_tier;
 
     public:
         const MySpline& _Spline() const { return spline; }
@@ -155,6 +156,8 @@ namespace Movement
         G3D::Vector3 FinalDestination() const { return Initialized() ? spline.getPoint(spline.last()) : G3D::Vector3(); }
         G3D::Vector3 CurrentDestination() const { return Initialized() ? spline.getPoint(point_Idx+1) : G3D::Vector3(); }
         int32 currentPathIdx() const;
+
+        Optional<AnimTier> GetAnimation() const { return anim_tier ? anim_tier->AnimTier : Optional<AnimTier>{}; }
 
         bool onTransport;
         bool splineIsFacingOnly;

--- a/src/server/game/Movement/Spline/MoveSplineFlag.h
+++ b/src/server/game/Movement/Spline/MoveSplineFlag.h
@@ -31,8 +31,10 @@ namespace Movement
         enum eFlags
         {
             None                = 0x00000000,
-                                                        // x00-x07 used as animation Ids storage in pair with Animation flag
-            Unknown0            = 0x00000008,           // NOT VERIFIED - does someting related to falling/fixed orientation
+            Unknown_0x1         = 0x00000001,           // NOT VERIFIED
+            Unknown_0x2         = 0x00000002,           // NOT VERIFIED
+            Unknown_0x4         = 0x00000004,           // NOT VERIFIED
+            Unknown_0x8         = 0x00000008,           // NOT VERIFIED - does someting related to falling/fixed orientation
             FallingSlow         = 0x00000010,
             Done                = 0x00000020,
             Falling             = 0x00000040,           // Affects elevation computation, can't be combined with Parabolic flag
@@ -63,10 +65,9 @@ namespace Movement
             Unknown10           = 0x80000000,           // NOT VERIFIED
 
             // Masks
-            // animation ids stored here, see AnimType enum, used with Animation flag
-            Mask_Animations     = 0x7,
+
             // flags that shouldn't be appended into SMSG_MONSTER_MOVE\SMSG_MONSTER_MOVE_TRANSPORT packet, should be more probably
-            Mask_No_Monster_Move = Mask_Animations | Done,
+            Mask_No_Monster_Move = Done,
         };
 
         uint32& raw() { return reinterpret_cast<uint32&>(*this); }
@@ -82,7 +83,6 @@ namespace Movement
         bool isSmooth() const { return (raw() & Catmullrom) != 0; }
         bool isLinear() const { return !isSmooth(); }
 
-        uint8 getAnimationId() const { return animId; }
         bool hasAllFlags(uint32 f) const { return (raw() & f) == f; }
         bool hasFlag(uint32 f) const { return (raw() & f) != 0; }
         uint32 operator & (uint32 f) const { return (raw() & f); }
@@ -94,16 +94,18 @@ namespace Movement
         void operator &= (uint32 f) { raw() &= f; }
         void operator |= (uint32 f) { raw() |= f; }
 
-        void EnableAnimation(uint8 anim) { raw() = (raw() & ~(Mask_Animations | Falling | Parabolic | FallingSlow | FadeObject)) | Animation | (anim & Mask_Animations); }
-        void EnableParabolic() { raw() = (raw() & ~(Mask_Animations | Falling | Animation | FallingSlow | FadeObject)) | Parabolic; }
+        void EnableAnimation() { raw() = (raw() & ~(Falling | Parabolic | FallingSlow | FadeObject)) | Animation; }
+        void EnableParabolic() { raw() = (raw() & ~(Falling | Animation | FallingSlow | FadeObject)) | Parabolic; }
         void EnableFlying() { raw() = (raw() & ~(Falling)) | Flying; }
-        void EnableFalling() { raw() = (raw() & ~(Mask_Animations | Parabolic | Animation | Flying)) | Falling; }
+        void EnableFalling() { raw() = (raw() & ~(Parabolic | Animation | Flying)) | Falling; }
         void EnableCatmullRom() { raw() = (raw() & ~SmoothGroundPath) | Catmullrom; }
         void EnableTransportEnter() { raw() = (raw() & ~TransportExit) | TransportEnter; }
         void EnableTransportExit() { raw() = (raw() & ~TransportEnter) | TransportExit; }
 
-        uint8 animId             : 3;
-        bool unknown0            : 1;
+        bool unknown0x1          : 1;
+        bool unknown0x2          : 1;
+        bool unknown0x4          : 1;
+        bool unknown0x8          : 1;
         bool fallingSlow         : 1;
         bool done                : 1;
         bool falling             : 1;

--- a/src/server/game/Movement/Spline/MoveSplineInit.h
+++ b/src/server/game/Movement/Spline/MoveSplineInit.h
@@ -24,16 +24,10 @@
 
 class Unit;
 
+enum class AnimTier : uint8;
+
 namespace Movement
 {
-    enum AnimType
-    {
-        ToGround    = 0, // 460 = ToGround, index of AnimationData.dbc
-        FlyToFly    = 1, // 461 = FlyToFly?
-        ToFly       = 2, // 458 = ToFly
-        FlyToGround = 3, // 463 = FlyToGround
-    };
-
     // Transforms coordinates from global to transport offsets
     class TransportPathTransform
     {
@@ -72,7 +66,7 @@ namespace Movement
         /* Plays animation after movement done
          * can't be combined with parabolic movement
          */
-        void SetAnimation(AnimType anim);
+        void SetAnimation(AnimTier anim);
 
         /* Adds final facing animation
          * sets unit's facing to specified point/angle after all path done
@@ -191,10 +185,12 @@ namespace Movement
         args.flags.EnableParabolic();
     }
 
-    inline void MoveSplineInit::SetAnimation(AnimType anim)
+    inline void MoveSplineInit::SetAnimation(AnimTier anim)
     {
         args.time_perc = 0.f;
-        args.flags.EnableAnimation(static_cast<uint8>(anim));
+        args.animTier.emplace();
+        args.animTier->AnimTier = anim;
+        args.flags.EnableAnimation();
     }
 
     inline void MoveSplineInit::SetFacing(G3D::Vector3 const& spot)

--- a/src/server/game/Movement/Spline/MoveSplineInitArgs.h
+++ b/src/server/game/Movement/Spline/MoveSplineInitArgs.h
@@ -22,6 +22,8 @@
 #include "MoveSplineFlag.h"
 #include "ObjectGuid.h"
 
+enum class AnimTier : uint8;
+
 namespace Movement
 {
     typedef std::vector<G3D::Vector3> PointsArray;
@@ -50,6 +52,12 @@ namespace Movement
         uint32 ParabolicCurveId = 0;
     };
 
+    struct AnimTierTransition
+    {
+        uint32 TierTransitionId = 0;
+        ::AnimTier AnimTier = ::AnimTier(0);
+    };
+
     struct MoveSplineInitArgs
     {
         MoveSplineInitArgs(size_t path_capacity = 16);
@@ -64,6 +72,7 @@ namespace Movement
         float time_perc;
         uint32 splineId;
         float initialOrientation;
+        Optional<AnimTierTransition> animTier;
         bool walk;
         bool HasVelocity;
         bool TransformForTransport;

--- a/src/server/game/Movement/Spline/MovementUtil.cpp
+++ b/src/server/game/Movement/Spline/MovementUtil.cpp
@@ -147,10 +147,10 @@ namespace Movement
 
     char const* SplineFlagNames[32] =
     {
-        STRINGIZE(AnimBit1           ), // 0x00000001
-        STRINGIZE(AnimBit2           ), // 0x00000002
-        STRINGIZE(AnimBit3           ), // 0x00000004
-        STRINGIZE(Unknown0           ), // 0x00000008
+        STRINGIZE(Unknown_0x1        ), // 0x00000001
+        STRINGIZE(Unknown_0x2        ), // 0x00000002
+        STRINGIZE(Unknown_0x3        ), // 0x00000004
+        STRINGIZE(Unknown_0x4        ), // 0x00000008
         STRINGIZE(FallingSlow        ), // 0x00000010
         STRINGIZE(Done               ), // 0x00000020
         STRINGIZE(Falling            ), // 0x00000040           // Not Compartible With Trajectory Movement

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -377,7 +377,7 @@ void WorldPackets::Movement::MonsterMove::InitializeSplineData(::Movement::MoveS
 
     if (splineFlags.animation)
     {
-        movementSpline.AnimTier = splineFlags.getAnimationId();
+        movementSpline.AnimTier = AsUnderlyingType(moveSpline.anim_tier->AnimTier);
         movementSpline.TierTransStartTime = moveSpline.SpecialTime;
     }
 

--- a/src/server/scripts/Draenor/Highmaul/boss_imperator_margok.cpp
+++ b/src/server/scripts/Draenor/Highmaul/boss_imperator_margok.cpp
@@ -350,7 +350,6 @@ struct boss_imperator_margok : public BossAI
                     me->RemoveFlag(UNIT_FIELD_FLAGS_2, UNIT_FLAG2_DISABLE_TURN);
 
                     me->SetAnimKitId(0);
-                    me->SetAnimTier(0);
                     me->SetDisableGravity(false);
                     me->SetHover(false);
                     me->SetReactState(REACT_AGGRESSIVE);
@@ -492,7 +491,6 @@ struct boss_imperator_margok : public BossAI
     void EnterEvadeMode() override
     {
         me->SetAnimKitId(0);
-        me->SetAnimTier(0);
         me->SetDisableGravity(false);
         me->SetHover(false);
         me->SetReactState(REACT_AGGRESSIVE);
@@ -1105,7 +1103,6 @@ struct boss_imperator_margok : public BossAI
             me->CastSpell(me, TransitionVisualPhase2, true);
             me->SetAnimKitId(AnimKitFlyingRune);
 
-            me->SetAnimTier(3);
             me->SetDisableGravity(true);
             me->SetHover(true);
 
@@ -1158,7 +1155,6 @@ struct boss_imperator_margok : public BossAI
 
             me->SetAnimKitId(AnimKitFlyingRune);
 
-            me->SetAnimTier(3);
             me->SetDisableGravity(true);
             me->SetHover(true);
 
@@ -1250,7 +1246,6 @@ struct boss_imperator_margok : public BossAI
 
             me->SetAnimKitId(AnimKitFlyingRune);
 
-            me->SetAnimTier(3);
             me->SetDisableGravity(true);
             me->SetHover(true);
 

--- a/src/server/scripts/Draenor/UpperBlackrockSpire/boss_commander_tharbek.cpp
+++ b/src/server/scripts/Draenor/UpperBlackrockSpire/boss_commander_tharbek.cpp
@@ -346,7 +346,7 @@ struct npc_ironbarb_skyreaver : public ScriptedAI
                 tharbek->CastSpell(me, SPELL_RIDE_VEHICLE, true);
             break;
         case 6:
-            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Ground);
             me->SetReactState(REACT_AGGRESSIVE);
 
             if (auto tharbek = me->GetAnyOwner())

--- a/src/server/scripts/Draenor/UpperBlackrockSpire/boss_ragewing_untamed.cpp
+++ b/src/server/scripts/Draenor/UpperBlackrockSpire/boss_ragewing_untamed.cpp
@@ -186,7 +186,6 @@ struct boss_ragewing_untamed : public BossAI
             {
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->SetOrientation(4.696021f);
                 me->SetFacingTo(4.696021f);

--- a/src/server/scripts/Draenor/UpperBlackrockSpire/boss_warlord_zaela.cpp
+++ b/src/server/scripts/Draenor/UpperBlackrockSpire/boss_warlord_zaela.cpp
@@ -195,7 +195,7 @@ struct boss_warlord_zaela : public BossAI
                 summon->GetMotionMaster()->MovePath((NPC_EMBERSCALE_IRONFLIGHT * 100) + rand, false);
             }
             else
-                summon->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+                summon->SetAnimTier(AnimTier::Ground);
             break;
         }
         }
@@ -322,7 +322,7 @@ struct npc_emberscale_ironflight : public CreatureAI
     {
         if (action == ACTION_DRAKE_INTRO)
         {
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Hover);
             me->GetMotionMaster()->MovePoint(1, drakePos[2]);
         }
     }
@@ -331,7 +331,7 @@ struct npc_emberscale_ironflight : public CreatureAI
     {
         if (me->GetEntry() == NPC_EMBERSCALE_IRONFLIGHT_2)
         {
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Hover);
             me->GetMotionMaster()->MovePoint(1, drakePos[5]);
         }
     }
@@ -401,7 +401,7 @@ struct npc_emberscale_matron : public ScriptedAI
     {
         me->SetReactState(REACT_PASSIVE);
         me->SetCanFly(true);
-        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+        me->SetAnimTier(AnimTier::Hover);
         me->SetSpeed(MOVE_FLIGHT, 4.0f);
     }
 

--- a/src/server/scripts/Draenor/zone_spires_of_arak.cpp
+++ b/src/server/scripts/Draenor/zone_spires_of_arak.cpp
@@ -35,7 +35,6 @@ public:
             me->GetMotionMaster()->MovePath(439156, true);
             me->SetCanFly(true);
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             me->SetReactState(REACT_AGGRESSIVE);
 
             events.Reset();
@@ -46,7 +45,6 @@ public:
         void EnterCombat(Unit* unit)
         {
             me->SetDisableGravity(false);
-            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3,  UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             me->CastSpell(me, SPELL_SOLAR_RADIATION);
             events.RescheduleEvent(EVENT_1, 12000, EVENT_GROUP_GROUND);
             events.RescheduleEvent(EVENT_2, 29000, EVENT_GROUP_GROUND);
@@ -89,7 +87,6 @@ public:
             {
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->SetReactState(REACT_AGGRESSIVE);
 
                 events.RescheduleEvent(EVENT_1, 12000, EVENT_GROUP_GROUND);
@@ -124,7 +121,6 @@ public:
 
 					me->SetCanFly(true);
 					me->SetDisableGravity(true);
-					me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
 					me->SetReactState(REACT_PASSIVE);
 					me->AttackStop();
 					Position pos;

--- a/src/server/scripts/EasternKingdoms/BlackwingDescent/boss_bwd_nefarian.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackwingDescent/boss_bwd_nefarian.cpp
@@ -433,7 +433,6 @@ public:
                     case EVENT_INTRO:
                         me->HandleEmoteCommand(EMOTE_ONESHOT_LIFTOFF);
                         me->SetDisableGravity(true);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                         me->SetCanFly(true);
                         me->GetMotionMaster()->Clear();
                         me->GetMotionMaster()->MovePoint(1, -126.518f, -233.342f, 36.358f); // Position on top of raid.
@@ -463,7 +462,6 @@ public:
 
                         me->HandleEmoteCommand(EMOTE_ONESHOT_LAND);
 
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                         me->SetDisableGravity(false);
                         me->SetCanFly(false);
@@ -490,7 +488,6 @@ public:
 
                         me->GetMotionMaster()->Clear();
                         me->HandleEmoteCommand(EMOTE_ONESHOT_LIFTOFF);
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                         me->SetDisableGravity(true);
                         me->SetCanFly(true);
 
@@ -525,7 +522,6 @@ public:
                         me->GetMotionMaster()->Clear();
                         me->HandleEmoteCommand(EMOTE_ONESHOT_LAND);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
                         me->SetCanFly(false);
                         events.RescheduleEvent(EVENT_RETURN, 1000);
                         events.RescheduleEvent(EVENT_GROUND, 1500);

--- a/src/server/scripts/Legion/AntorusTheBurningThrone/boss_coven_shivarres.cpp
+++ b/src/server/scripts/Legion/AntorusTheBurningThrone/boss_coven_shivarres.cpp
@@ -565,7 +565,7 @@ struct boss_coven_shivarres_generic : ScriptedAI
 
                 me->AddDelayedCombat(2000, [this] () -> void
                 {
-                    me->SetAnimTier(3);
+                    me->SetAnimTier(AnimTier::Fly);
                     me->SetDisableGravity(true);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                     me->RemoveAurasAllDots();
@@ -590,7 +590,7 @@ struct boss_coven_shivarres_generic : ScriptedAI
             case 1:
             case 2:
             case 3:
-                me->SetAnimTier(0);
+                me->SetAnimTier(AnimTier::Ground);
                 me->CastSpellDelay(me, SPELL_SENSE_OF_DREAD, true, 500);
                 me->CastSpellDelay(me, tormentSpellId[id], false, 500);
                 //DEBUG!!!

--- a/src/server/scripts/Legion/BlackRookHoldDungeon/boss_illysanna_ravencrest.cpp
+++ b/src/server/scripts/Legion/BlackRookHoldDungeon/boss_illysanna_ravencrest.cpp
@@ -129,7 +129,7 @@ struct boss_illysanna_ravencrest : public BossAI
         DoCast(me, SPELL_FURY_POWER_OVERRIDE, true);
         DoCast(me, SPELL_REGEN_POWER, true);
         me->SetReactState(REACT_AGGRESSIVE);
-        me->SetAnimTier(0);
+        me->SetAnimTier(AnimTier::Ground);
         SetFlyMode(false);
         phaseTwo = false;
         achievement = true;
@@ -193,14 +193,14 @@ struct boss_illysanna_ravencrest : public BossAI
                 Talk(SAY_EYE_BEAMS);
                 me->GetMotionMaster()->Clear(false);
                 me->SetFacingTo(4.05f);
-                me->SetAnimTier(3);
+                me->SetAnimTier(AnimTier::Fly);
                 events.RescheduleEvent(EVENT_SUMMON_ADDS, 1000);
                 events.RescheduleEvent(EVENT_EYE_BEAMS, 2000);
             }
             if (id == 1)
             {
                 SetFlyMode(false);
-                me->SetAnimTier(0);
+                me->SetAnimTier(AnimTier::Ground);
                 me->SetReactState(REACT_AGGRESSIVE, 500);
                 DoCast(me, SPELL_REGEN_POWER, true);
                 phaseTwo = false;

--- a/src/server/scripts/Legion/TheArcway/boss_naltira.cpp
+++ b/src/server/scripts/Legion/TheArcway/boss_naltira.cpp
@@ -184,7 +184,6 @@ public:
             {
                 me->SetDisableGravity(false);
                 me->RemoveAurasDueToSpell(SPELL_WEB_BEAM_BOSS);
-                me->SetAnimTier(0);
                 me->SetReactState(REACT_AGGRESSIVE);
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_IMMUNE_TO_NPC | UNIT_FLAG_IMMUNE_TO_PC | UNIT_FLAG_NOT_ATTACKABLE_1);
             }

--- a/src/server/scripts/Legion/TheEmeraldNightmare/boss_elerethe_renferal.cpp
+++ b/src/server/scripts/Legion/TheEmeraldNightmare/boss_elerethe_renferal.cpp
@@ -235,7 +235,7 @@ struct boss_elerethe_renferal : public BossAI
 
     void JustDied(Unit* /*killer*/) override
     {
-        me->SetAnimTier(0);
+        me->SetAnimTier(AnimTier::Ground);
         RemoveEventTrash();
         _JustDied();
     }
@@ -245,7 +245,7 @@ struct boss_elerethe_renferal : public BossAI
         BossAI::EnterEvadeMode();
         RemoveEventTrash();
         me->RemoveAllAuras();
-        me->SetAnimTier(0);
+        me->SetAnimTier(AnimTier::Ground);
         me->NearTeleportTo(11405.6f, 11400.7f, -85.32f, 4.62f);
         me->GetMotionMaster()->MoveIdle();
     }
@@ -381,7 +381,6 @@ struct boss_elerethe_renferal : public BossAI
                     DoCast(me, SPELL_VILE_AMBUSH_FILTER, true);
                     break;
                 case SPELL_VILE_AMBUSH_JUMP:
-                    me->SetAnimTier(0);
                     me->SetDisableGravity(false);
                     me->SetReactState(REACT_AGGRESSIVE);
                     if (IsMythicRaid())

--- a/src/server/scripts/Legion/TombOfSargeras/boss_Kiljaeden.cpp
+++ b/src/server/scripts/Legion/TombOfSargeras/boss_Kiljaeden.cpp
@@ -474,7 +474,7 @@ struct boss_tos_kiljaeden : BossAI
         else if (id == 4)
         {
             SetFlyMode(false);
-            me->SetAnimTier(0);
+            me->SetAnimTier(AnimTier::Ground);
             me->GetMotionMaster()->MoveFall();
             me->RemoveAurasDueToSpell(SPELL_NETHER_GALE);
             me->SetReactState(REACT_AGGRESSIVE, 3000);
@@ -499,7 +499,6 @@ struct boss_tos_kiljaeden : BossAI
                 DefaultEvents();
                 me->StopAttack(true);
                 SetFlyMode(true);
-                me->SetAnimTier(3);
                 me->SetSpeed(MOVE_FLIGHT, 3.0f, true);
                 me->GetMotionMaster()->MovePoint(1, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 10.0f, false);
                 DoCast(me, SPELL_WINGSPAN_SOUND, true);

--- a/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
+++ b/src/server/scripts/Northrend/ChamberOfAspects/RubySanctum/boss_saviana_ragefire.cpp
@@ -116,7 +116,6 @@ class boss_saviana_ragefire : public CreatureScript
                     case POINT_LAND_GROUND:
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetReactState(REACT_AGGRESSIVE);
                         DoStartMovement(me->getVictim());
                         break;
@@ -159,7 +158,6 @@ class boss_saviana_ragefire : public CreatureScript
                         {
                             me->SetCanFly(true);
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
                             Position pos;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_blood_queen_lana_thel.cpp
@@ -181,7 +181,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                     if (Creature* minchar = me->FindNearestCreature(NPC_INFILTRATOR_MINCHAR_BQ, 200.0f))
                     {
                         minchar->SetUInt32Value(UNIT_FIELD_EMOTE_STATE, 0);
-                        minchar->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
+                        minchar->SetAnimTier(AnimTier::Ground);
                         minchar->SetCanFly(false);
                         minchar->RemoveAllAuras();
                         minchar->GetMotionMaster()->MoveCharge(4629.3711f, 2782.6089f, 401.5301f, SPEED_CHARGE/3.0f);
@@ -212,7 +212,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 else
                 {
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                     me->SetCanFly(true);
                     me->GetMotionMaster()->MovePoint(POINT_MINCHAR, mincharPos);
                 }
@@ -227,7 +226,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 {
                     _killMinchar = false;
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                     me->SetCanFly(true);
                     me->GetMotionMaster()->MovePoint(POINT_MINCHAR, mincharPos);
                 }
@@ -244,7 +242,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE | UNIT_FLAG_NON_ATTACKABLE);
                 instance->DoRemoveAurasDueToSpellOnPlayers(SPELL_UNCONTROLLABLE_FRENZY);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                 me->SetCanFly(false);
                 me->SetReactState(REACT_AGGRESSIVE);
                 _JustReachedHome();
@@ -301,7 +298,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                         break;
                     case POINT_GROUND:
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                         me->SetCanFly(false);
                         me->SetReactState(REACT_AGGRESSIVE);
                         if (Unit* victim = me->SelectVictim())
@@ -387,7 +383,7 @@ class boss_blood_queen_lana_thel : public CreatureScript
                             break;
                         }
                         case EVENT_DELIRIOUS_SLASH:
-                            if (!me->HasByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER))
+                            if (me->GetAnimTier() != AnimTier::Fly)
                                 if (Unit * target = me->GetUnit(*me, _offtank))
                                     DoCast(target, SPELL_DELIRIOUS_SLASH);
                             events.ScheduleEvent(EVENT_DELIRIOUS_SLASH, urand(20000, 24000), EVENT_GROUP_NORMAL);
@@ -440,7 +436,6 @@ class boss_blood_queen_lana_thel : public CreatureScript
                             break;
                         case EVENT_AIR_START_FLYING:
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND);
                             me->SetCanFly(true);
                             me->GetMotionMaster()->MovePoint(POINT_AIR, airPos);
                             break;

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_sindragosa.cpp
@@ -276,7 +276,6 @@ class boss_sindragosa : public CreatureScript
                     me->setActive(true);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetSpeed(MOVE_FLIGHT, 4.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&SindragosaFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
@@ -305,7 +304,6 @@ class boss_sindragosa : public CreatureScript
                         me->setActive(false);
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetHomePosition(SindragosaLandPos);
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                         me->SetReactState(REACT_AGGRESSIVE);
@@ -340,7 +338,6 @@ class boss_sindragosa : public CreatureScript
                     {
                         me->SetCanFly(false);
                         me->SetDisableGravity(false);
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                         me->SetReactState(REACT_AGGRESSIVE);
                         if (me->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
                             me->GetMotionMaster()->MovementExpired();
@@ -497,7 +494,6 @@ class boss_sindragosa : public CreatureScript
                             Talk(SAY_AIR_PHASE);
                             me->SetCanFly(true);
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
                             Position pos;
@@ -746,7 +742,6 @@ class npc_spinestalker : public CreatureScript
                     me->setActive(true);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetSpeed(MOVE_FLIGHT, 2.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&SpinestalkerFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
@@ -767,7 +762,6 @@ class npc_spinestalker : public CreatureScript
                 me->setActive(false);
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->SetHomePosition(SpinestalkerLandPos);
                 me->SetFacingTo(SpinestalkerLandPos.GetOrientation());
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
@@ -884,7 +878,6 @@ class npc_rimefang : public CreatureScript
                     me->setActive(true);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetSpeed(MOVE_FLIGHT, 2.0f);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                     float moveTime = me->GetExactDist(&RimefangFlyPos) / (me->GetSpeed(MOVE_FLIGHT) * 0.001f);
@@ -905,7 +898,6 @@ class npc_rimefang : public CreatureScript
                 me->setActive(false);
                 me->SetCanFly(false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->SetHomePosition(RimefangLandPos);
                 me->SetFacingTo(RimefangLandPos.GetOrientation());
                 me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);

--- a/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
+++ b/src/server/scripts/Northrend/IcecrownCitadel/boss_the_lich_king.cpp
@@ -556,7 +556,6 @@ class boss_the_lich_king : public CreatureScript
                 _JustDied();
                 DoCastAOE(SPELL_PLAY_MOVIE, false);
                 me->SetDisableGravity(false);
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                 me->GetMotionMaster()->MoveFall();
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_DISENGAGE, me);
                 if (Creature* frostmourne = me->FindNearestCreature(NPC_FROSTMOURNE_TRIGGER, 50.0f))
@@ -1154,7 +1153,6 @@ class boss_the_lich_king : public CreatureScript
                             sCreatureTextMgr->SendSound(me, SOUND_PAIN, CHAT_MSG_MONSTER_YELL, ObjectGuid::Empty, TEXT_RANGE_NORMAL, TEAM_OTHER, false);
                             // set flight
                             me->SetDisableGravity(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                             me->GetMotionMaster()->MovePoint(POINT_LK_OUTRO_2, OutroFlying);
                             break;
                         case EVENT_OUTRO_TALK_7:

--- a/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
+++ b/src/server/scripts/Northrend/Nexus/EyeOfEternity/boss_malygos.cpp
@@ -361,7 +361,6 @@ public:
             finalEvent = false;
 
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             // TO DO: find what in core is making boss slower than in retail (when correct speed data) or find missing movement flag update or forced spline change
             me->SetSpeed(MOVE_FLIGHT, _flySpeed * 0.25f);
             if (_despawned)

--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_razorscale.cpp
@@ -187,7 +187,6 @@ public:
         {
             _Reset();
             me->SetCanFly(true);
-            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
             me->SetReactState(REACT_PASSIVE);
             PermaGround = false;
@@ -257,7 +256,7 @@ public:
                             phase = PHASE_FLIGHT;
                             events.SetPhase(PHASE_FLIGHT);
                             me->SetCanFly(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                            me->SetAnimTier(AnimTier::Ground);
                             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                             me->SetReactState(REACT_PASSIVE);
                             me->AttackStop();
@@ -272,7 +271,7 @@ public:
                         case EVENT_LAND:
                             me->SetCanFly(false);
                             me->NearTeleportTo(586.966f, -175.534f, 391.517f, 1.692f);
-                            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                            me->SetAnimTier(AnimTier::Ground);
                             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
                             DoCast(me, SPELL_STUN, true);
                             if (Creature *pCommander = me->GetCreature(*me, instance->GetGuidData(DATA_EXP_COMMANDER)))
@@ -383,7 +382,7 @@ public:
             events.SetPhase(PHASE_PERMAGROUND);
             me->NearTeleportTo(586.966f, -175.534f, 391.517f, 1.692f);
             me->SetCanFly(false);
-            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Ground);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE);
             me->SetReactState(REACT_AGGRESSIVE);
             me->RemoveAurasDueToSpell(SPELL_STUN);

--- a/src/server/scripts/Pandaria/HeartFear/boss_vizier_zorlok.cpp
+++ b/src/server/scripts/Pandaria/HeartFear/boss_vizier_zorlok.cpp
@@ -87,7 +87,6 @@ class boss_vizier_zorlok : public CreatureScript
             {
                 me->SetCanFly(true);
                 me->SetDisableGravity(true);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
             }
 
             uint8 newindex, lastindex, flycount;
@@ -143,7 +142,6 @@ class boss_vizier_zorlok : public CreatureScript
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL);
                     me->SetCanFly(true);
                     me->SetDisableGravity(true);
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 }
                 else
@@ -151,7 +149,6 @@ class boss_vizier_zorlok : public CreatureScript
                     flyMove = false;
                     me->SetCanFly(false);
                     me->SetDisableGravity(false);
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
                 }
             }

--- a/src/server/scripts/Pandaria/MogushanVault/boss_elegon.cpp
+++ b/src/server/scripts/Pandaria/MogushanVault/boss_elegon.cpp
@@ -117,7 +117,7 @@ class boss_elegon : public CreatureScript
                 pInstance = creature->GetInstanceScript();
                 me->SetCanFly(true);
                 me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_REMOVE_CLIENT_CONTROL);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                me->SetAnimTier(AnimTier::Fly);
             }
 
             InstanceScript* pInstance;

--- a/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_galakras.cpp
+++ b/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_galakras.cpp
@@ -661,7 +661,7 @@ class boss_galakras : public CreatureScript
                             break;
                         case EVENT_GALAKRAS_EXECUTE_2:
                             me->SetReactState(REACT_AGGRESSIVE);
-                            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
+                            me->SetAnimTier(AnimTier::Ground);
                             me->RemoveAurasDueToSpell(SPELL_ANTIAIR_CANNON);
                             events.RescheduleEvent(EVENT_GALAKRAS_EXECUTE_3, 0);
                             events.RescheduleEvent(EVENT_GALAKRAS_EXECUTE_4, 20000);
@@ -1802,7 +1802,7 @@ class npc_dragonmaw_proto_drake : public CreatureScript
                             break;
                         case EVENT_PROTO_DRAKE_FLY:
                             me->SetCanFly(true);
-                            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                            me->SetAnimTier(AnimTier::Fly);
                             me->GetMotionMaster()->MoveRandom(5.0f);
                             DoZoneInCombat(me, 180.0f);
                             events.RescheduleEvent(EVENT_DRAKE_DRAKEFIRE, 7000);

--- a/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_korkron_dark_shaman.cpp
+++ b/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_korkron_dark_shaman.cpp
@@ -816,7 +816,7 @@ public:
             instance = creature->GetInstanceScript();
             me->SetReactState(REACT_PASSIVE);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NON_ATTACKABLE | UNIT_FLAG_NOT_SELECTABLE);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Fly);
             DoCast(me, SPELL_TOXIC_TORNADO_TR_AURA, true);
         }
 

--- a/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_paragons_of_the_klaxxi.cpp
+++ b/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_paragons_of_the_klaxxi.cpp
@@ -494,7 +494,7 @@ public:
             summons.DespawnAll();
             for (uint8 n = 0; n < 4; n++)
                 me->RemoveAurasDueToSpell(removeaurasentry[n]);
-            me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+            me->SetAnimTier(AnimTier::Ground);
             me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_NPC_FLAG_SPELLCLICK);
             me->SetReactState(REACT_PASSIVE);
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
@@ -592,7 +592,7 @@ public:
             case ACTION_KLAXXI_IN_PROGRESS:
                 instance->SendEncounterUnit(ENCOUNTER_FRAME_ENGAGE, me);
                 me->GetMotionMaster()->MoveJump(1582.4f, -5684.9f, -313.635f, 15.0f, 15.0f, 1);
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                me->SetAnimTier(AnimTier::Fly);
                 break;
             case ACTION_RE_ATTACK:
                 me->SetFullHealth();
@@ -601,7 +601,7 @@ public:
                 DoZoneInCombat(me, 150.0f);
                 break;
             case ACTION_RE_ATTACK_KILRUK:
-                me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                me->SetAnimTier(AnimTier::Ground);
                 me->SetReactState(REACT_AGGRESSIVE);
                 events.RescheduleEvent(EVENT_DEATH_FROM_ABOVE, 34000);
                 break;
@@ -628,7 +628,7 @@ public:
                 case 1:
                     if (Player* pl = me->FindNearestPlayer(250.0f, true))
                     {
-                        me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                        me->SetAnimTier(AnimTier::Ground);
                         me->RemoveAurasDueToSpell(SPELL_READY_TO_FIGHT);
                         me->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
                         if (me->GetEntry() != NPC_HISEK)
@@ -650,7 +650,7 @@ public:
                     DoCast(me, SPELL_HURL_AMBER);
                     break;
                 case 3:
-                    me->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                    me->SetAnimTier(AnimTier::Ground);
                     me->SetReactState(REACT_AGGRESSIVE);
                     events.RescheduleEvent(EVENT_FLASH, 10000);
                     break;
@@ -953,7 +953,7 @@ public:
                         dfatargetGuid = pl->GetGUID();
                         events.DelayEvents(6000);
                         me->StopAttack();
-                        me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                        me->SetAnimTier(AnimTier::Fly);
                         me->GetMotionMaster()->MoveJump(me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 10.0f, 15.0f, 15.0f, 4);
                     }
                     else
@@ -1036,7 +1036,7 @@ public:
                     //Karoz
                 case EVENT_HURL_AMBER:
                     me->StopAttack();
-                    me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                    me->SetAnimTier(AnimTier::Fly);
                     if (Creature* ab = me->FindNearestCreature(NPC_AMBER_BOMB, 110.0f, true))
                         me->GetMotionMaster()->MoveJump(ab->GetPositionX(), ab->GetPositionY(), ab->GetPositionZ() + 5.0f, 15.0f, 15.0f, 2);
                     break;

--- a/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_siegecrafter_blackfuse.cpp
+++ b/src/server/scripts/Pandaria/SiegeofOrgrimmar/boss_siegecrafter_blackfuse.cpp
@@ -1501,7 +1501,7 @@ public:
             me->SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_NOT_SELECTABLE);
             if (me->GetEntry() == NPC_LASER_ARRAY && !me->ToTempSummon())
             {
-                me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
+                me->SetAnimTier(AnimTier::Fly);
                 me->AddAura(SPELL_CONVEYOR_DEATH_BEAM_V, me);
                 DoCast(me, SPELL_CONVEYOR_DEATH_BEAM_AT, true);
             }

--- a/src/server/scripts/Pandaria/ThroneOfThunder/boss_iron_qon.cpp
+++ b/src/server/scripts/Pandaria/ThroneOfThunder/boss_iron_qon.cpp
@@ -203,13 +203,11 @@ class npc_iron_qon_maunt : public CreatureScript
                     {
                         maunt->SetCanFly(true);
                         maunt->SetDisableGravity(true);
-                        maunt->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     }
                     else
                     {
                         maunt->SetCanFly(false);
                         maunt->SetDisableGravity(false);
-                        maunt->RemoveByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
                     }
                 }
             }

--- a/src/server/scripts/Pandaria/boss_nalak.cpp
+++ b/src/server/scripts/Pandaria/boss_nalak.cpp
@@ -37,7 +37,6 @@ public:
         {
             me->SetCanFly(true);
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_ALWAYS_STAND | UNIT_BYTE1_FLAG_HOVER);
         }
 
         EventMap events;
@@ -169,7 +168,6 @@ public:
         {
             me->SetCanFly(true);
             me->SetDisableGravity(true);
-            me->SetByteFlag(UNIT_FIELD_BYTES_1, 3, UNIT_BYTE1_FLAG_HOVER);
         }
 
         void Reset() override

--- a/src/server/scripts/World/custom_events.cpp
+++ b/src/server/scripts/World/custom_events.cpp
@@ -2658,7 +2658,7 @@ struct boss_new_year_2019_atray : public ScriptedAI
         events.RescheduleEvent(ATRAY_DEATHFROST, urand(25000, 30000));
         me->StopAttack(true);
         SetFlyMode(true);
-        me->SetAnimTier(3);
+        me->SetAnimTier(AnimTier::Fly);
         me->AddDelayedEvent(2000, [this]() -> void
         {
             me->GetMotionMaster()->MovePoint(1, AtrayFlyPhasePos[urand(0, 7)], false);
@@ -2809,7 +2809,7 @@ struct boss_new_year_2019_atray : public ScriptedAI
         case 20:
             me->SetFacingTo(0.8f);
             SetFlyMode(false);
-            me->SetAnimTier(0);
+            me->SetAnimTier(AnimTier::Ground);
             me->GetMotionMaster()->MoveFall();
             me->SetReactState(REACT_AGGRESSIVE, 2000);
             StartDefaultEvents(false, true);
@@ -2824,7 +2824,7 @@ struct boss_new_year_2019_atray : public ScriptedAI
         explodeCasted = 0;
         me->SetReactState(REACT_AGGRESSIVE);
         SetFlyMode(false);
-        me->SetAnimTier(0);
+        me->SetAnimTier(AnimTier::Ground);
         phase = false;
         me->RemoveAura(SPELL_ATRAY_FURY);
         ragephase = false;
@@ -3760,7 +3760,7 @@ struct npc_new_year_2019_evala_minion : public VehicleAI
     {
         me->StopAttack(true);
         SetFlyMode(true);
-        me->SetAnimTier(3);
+        me->SetAnimTier(AnimTier::Fly);
         me->SetSpeed(MOVE_FLIGHT, 0.2f);
         me->GetMotionMaster()->MovePoint(1, me->GetPositionX(), me->GetPositionY(), me->GetPositionZ() + 70.f);
         me->AddDelayedEvent(14000, [this]() -> void


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- Updated based on TCPP/TC work
  - Ref: https://github.com/TrinityCore/TrinityCore/commit/ee620856ad2918ae7ce91a37a980d9f2129a074a

**Issues addressed:**

Auto updates anim tier in calls to `SetDisableGravity` and `SetHover`, which removes the need for a lot of manual anim tier handling.

This fixes visuals on some mobs, like [Mature Netherwing Drake](https://www.wowhead.com/npc=21648)

Before:

![anim-tier-bad](https://github.com/user-attachments/assets/00f1977d-0df0-4a39-b25a-44ecfb0818f8)

After:

![anim-tier-good](https://github.com/user-attachments/assets/6276200e-b598-4c3b-a9f5-6f3092285c17)

**Tests performed:**

tested in-game, but needs more testing

**Known issues and TODO list:** (add/remove lines as needed)

- Some of the updated bosses may be affected

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
