### PR TITLE
Core/Scripts: fix guild, group, world state script loading

### DIFF
--- a/src/server/game/Scripting/ScriptMgr.cpp
+++ b/src/server/game/Scripting/ScriptMgr.cpp
@@ -125,18 +125,6 @@ template<>
 struct is_script_database_bound<AchievementRewardScript>
   : std::true_type { };
 
-template<>
-struct is_script_database_bound<GuildScript>
-  : std::true_type { };
-
-template<>
-struct is_script_database_bound<GroupScript>
-  : std::true_type { };
-
-template<>
-struct is_script_database_bound<WorldStateScript>
-  : std::true_type { };
-
 enum Spells
 {
     SPELL_HOTSWAP_VISUAL_SPELL_EFFECT = 40162 // 59084


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

- These were incorrectly converted as database bound in #240 

**Issues addressed:**

Leaving instance group while inside a dungeon will teleport the player out again.

**Tests performed:**

tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

none

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
--->
